### PR TITLE
ZKR-1291 cvc5 error handling

### DIFF
--- a/korrekt/Cargo.toml
+++ b/korrekt/Cargo.toml
@@ -9,6 +9,7 @@ env_logger = "0.9.0"
 log = "0.4.17"
 try-catch = "0.2.2"
 anyhow = "1.0.71"
+regex = "1.8.4"
 
 [features]
 default = []


### PR DESCRIPTION
In the current implementation, the analyzer returns a result that the circuit is over-constrained if the result of the SMT Solver is an error. Add proper error handling.