### PR TITLE
ZKR-1317-Added regex to parse the output of the smt solver

### DIFF
--- a/korrekt/Cargo.toml
+++ b/korrekt/Cargo.toml
@@ -9,6 +9,7 @@ env_logger = "0.9.0"
 log = "0.4.17"
 try-catch = "0.2.2"
 anyhow = "1.0.71"
+regex = "1.8.4"
 
 [features]
 default = []


### PR DESCRIPTION
Modified the `extract_model_response()` function in  `smt_parser.rs` to use regex.