### PR TITLE
ZKR-1371-Update-Abstract-Interpretation-Code

### DIFF
--- a/korrekt/src/circuit_analyzer/analyzer.rs
+++ b/korrekt/src/circuit_analyzer/analyzer.rs
@@ -165,8 +165,6 @@ impl<'b, F: FieldExt> Analyzer<F> {
                                 let advices = abstract_expr::extract_columns(poly);
                                 let eval = abstract_expr::eval_abstract(poly, &selectors);
 
-                                column.index();
-
                                 if eval != AbsResult::Zero && advices.contains(&(column, rotation))
                                 {
                                     used = true;

--- a/korrekt/src/circuit_analyzer/layouter.rs
+++ b/korrekt/src/circuit_analyzer/layouter.rs
@@ -83,6 +83,8 @@ impl<'a, F: Field> Layouter<F> for &'a mut AnalyticLayouter<F> {
 
         self.eq_table.insert(left, right);
         Ok(())
+
+        //todo!("handle instance columns"); Quantstamp ticket ZKR-1881
     }
 
     fn get_root(&mut self) -> &mut Self::Root {
@@ -94,8 +96,10 @@ impl<'a, F: Field> Layouter<F> for &'a mut AnalyticLayouter<F> {
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
+        // implementation not needed at this time
     }
 
     fn pop_namespace(&mut self, _gadget_name: Option<String>) {
+        // implementation not needed at this time
     }
 }

--- a/korrekt/src/circuit_analyzer/layouter.rs
+++ b/korrekt/src/circuit_analyzer/layouter.rs
@@ -83,7 +83,6 @@ impl<'a, F: Field> Layouter<F> for &'a mut AnalyticLayouter<F> {
 
         self.eq_table.insert(left, right);
         Ok(())
-        //todo!("handle instance columns") ticket created: https://quantstamp.atlassian.net/browse/ZKR-1238
     }
 
     fn get_root(&mut self) -> &mut Self::Root {
@@ -95,10 +94,8 @@ impl<'a, F: Field> Layouter<F> for &'a mut AnalyticLayouter<F> {
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
-        //todo!("handle namespaces");ticket created: https://quantstamp.atlassian.net/browse/ZKR-1238
     }
 
     fn pop_namespace(&mut self, _gadget_name: Option<String>) {
-        //todo!("handle namespaces");ticket created: https://quantstamp.atlassian.net/browse/ZKR-1238
     }
 }


### PR DESCRIPTION
There are some minor changes related to removing some TODOs and deleting an unused line of code. 

And also a question from [second round of code review](https://github.com/quantstamp/research-zk-fm/issues/10):

> This is more of a question then a suggestion. In the below function, do we intend on counting RegionColumn::Selector? I'm asking because in that case used == false but we call continue which skips the counting.
>     pub fn analyze_unconstrained_cells(&mut self) -> Result<AnalyzerOutput> {
>         let mut count = 0;
>         for region in self.layouter.regions.iter() {
>             let selectors = HashSet::from_iter(region.selectors().into_iter());
> 
>             for (reg_column, rotation) in region.columns.iter().cloned() {
>                 let mut used = false;
> 
>                 match reg_column {
>                     RegionColumn::Selector(_) => continue,
>                     RegionColumn::Column(column) => {
>                         for gate in self.cs.gates.iter() {
>                             for poly in gate.polynomials() {
>                                 let advices = abstract_expr::extract_columns(poly);
>                                 let eval = abstract_expr::eval_abstract(poly, &selectors);
> 
>                                 column.index(); // <<<<<<<<<<<<<<<<<<<<<
> 
>                                 if eval != AbsResult::Zero && advices.contains(&(column, rotation))
>                                 {
>                                     used = true;
>                                 }
>                             }
>                         }
>                     }
>                 };
> 
>                 if !used {
>                     count += 1;
>                     self.log.push(format!("unconstrained cell in \"{}\" region: {:?} (rotation: {:?}) -- very likely a bug.", region.name,  reg_column, rotation));
>                 }
>             }
>         }