### PR TITLE
ZKR-3207-Disabled-Selector-Optimization

### DIFF
--- a/korrekt/src/circuit_analyzer/analyzer.rs
+++ b/korrekt/src/circuit_analyzer/analyzer.rs
@@ -1170,7 +1170,6 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 cons_str_vec.push(node_str);
                                 if !var.is_empty() {
                                     non_zero_expression.push(true);
-                                    //TODO: check if we can optimize analyzer based on disabled selectores on lookups: ZKR-3207
                                     lookup_arg_cells.push(var);
                                 }
                             }
@@ -1219,7 +1218,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                         }
 
                         if !cons_str_vec.is_empty() && !lookup_mapping.is_empty() {
-                            let uninterpreted_func_name =
+                            let funcion_name =
                                 format!("isInLookupTable{}", lookup_index);
                             if !lookup_func_map.contains_key(&lookup_index) {
                                 lookup_func_map.insert(lookup_index, true);
@@ -1228,7 +1227,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                     // lookup_interpreted_func {
                                     smt::write_define_fn(
                                         printer,
-                                        uninterpreted_func_name.clone(),
+                                        funcion_name.clone(),
                                         function_input,
                                         "Bool".to_owned(),
                                         function_body,
@@ -1236,7 +1235,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 } else {
                                     smt::write_declare_fn(
                                         printer,
-                                        uninterpreted_func_name.clone(),
+                                        funcion_name.clone(),
                                         "F".to_owned(),
                                         "Bool".to_owned(),
                                     );
@@ -1252,14 +1251,14 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 let cons_str = cons_str.trim();
                                 smt::write_assert_boolean_func(
                                     printer,
-                                    uninterpreted_func_name.clone(),
+                                    funcion_name.clone(),
                                     cons_str.to_owned(),
                                 );
                             } else {
                                 for cons_str in cons_str_vec.iter() {
                                     smt::write_assert_boolean_func(
                                         printer,
-                                        uninterpreted_func_name.clone(),
+                                        funcion_name.clone(),
                                         format!("({})", cons_str).to_owned(),
                                     );
                                 }
@@ -1301,7 +1300,6 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 );
                                 cons_str_vec.push(node_str);
                                 if !var.is_empty() {
-                                    //TODO: check if we can optimize analyzer based on disabled selectores on lookups: ZKR-3207
                                     lookup_arg_cells.push(var);
                                 }
                             }
@@ -1345,7 +1343,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                             &self.lookup_mappings.push(lookup_mapping.clone());
                         }
                         if !cons_str_vec.is_empty() && !lookup_mapping.is_empty() {
-                            let uninterpreted_func_name =
+                            let function_name =
                                 format!("isInLookupTable{}", lookup_index);
                             if !lookup_func_map.contains_key(&lookup_index) {
                                 lookup_func_map.insert(lookup_index, true);
@@ -1354,7 +1352,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                     // lookup_interpreted_func {
                                     smt::write_define_fn(
                                         printer,
-                                        uninterpreted_func_name.clone(),
+                                        function_name.clone(),
                                         function_input,
                                         "Bool".to_owned(),
                                         function_body,
@@ -1362,7 +1360,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 } else {
                                     smt::write_declare_fn(
                                         printer,
-                                        uninterpreted_func_name.clone(),
+                                        function_name.clone(),
                                         "F".to_owned(),
                                         "Bool".to_owned(),
                                     );
@@ -1377,14 +1375,14 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 let cons_str = cons_str.trim();
                                 smt::write_assert_boolean_func(
                                     printer,
-                                    uninterpreted_func_name.clone(),
+                                    function_name.clone(),
                                     cons_str.to_owned(),
                                 );
                             } else {
                                 for cons_str in cons_str_vec.iter() {
                                     smt::write_assert_boolean_func(
                                         printer,
-                                        uninterpreted_func_name.clone(),
+                                        function_name.clone(),
                                         format!("({})", cons_str).to_owned(),
                                     );
                                 }

--- a/korrekt/src/circuit_analyzer/analyzer.rs
+++ b/korrekt/src/circuit_analyzer/analyzer.rs
@@ -9,7 +9,6 @@ use std::{
     process::Command,
 };
 
-use crate::{circuit_analyzer::abstract_expr::{self, AbsResult}, io::analyzer_io_type::LookupMethod};
 use crate::io::analyzer_io::{output_result, retrieve_user_input_for_underconstrained};
 use crate::io::analyzer_io_type::{
     AnalyzerInput, AnalyzerOutput, AnalyzerOutputStatus, AnalyzerType, VerificationMethod,
@@ -18,6 +17,10 @@ use crate::smt_solver::{
     smt,
     smt::Printer,
     smt_parser::{self, ModelResult, Satisfiability},
+};
+use crate::{
+    circuit_analyzer::abstract_expr::{self, AbsResult},
+    io::analyzer_io_type::LookupMethod,
 };
 
 use super::analyzable::Analyzable;
@@ -58,6 +61,12 @@ pub enum Operation {
     NotEqual,
     And,
     Or,
+}
+
+#[derive(Debug)]
+pub enum IsZeroExpression {
+    Zero,
+    NonZero,
 }
 
 impl<'b, F: AnalyzableField> Analyzer<F> {
@@ -473,21 +482,30 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
         es: &HashMap<Selector, Vec<usize>>,
         fixed: &Vec<Vec<CellValue<F>>>,
         cell_to_cycle_head: &HashMap<String, String>,
-    ) -> (String, NodeType) {
+    ) -> (String, NodeType, IsZeroExpression) {
+        let mut is_zero_expression = IsZeroExpression::NonZero;
         match &poly {
             Expression::Constant(a) => {
                 let constant_decimal_value =
                     u64::from_str_radix(format!("{:?}", a).strip_prefix("0x").unwrap(), 16)
                         .unwrap();
 
+                if constant_decimal_value == 0 {
+                    return ("as ff0 F".to_owned(), NodeType::Constant, IsZeroExpression::Zero);
+                }
+
                 let term = format!("(as ff{:?} F)", constant_decimal_value);
-                (term, NodeType::Constant)
+                (term, NodeType::Constant, is_zero_expression)
             }
             Expression::Selector(a) => {
                 if es.contains_key(a) {
-                    ("(as ff1 F)".to_owned(), NodeType::Fixed)
+                    ("(as ff1 F)".to_owned(), NodeType::Fixed, is_zero_expression)
                 } else {
-                    ("(as ff0 F)".to_owned(), NodeType::Fixed)
+                    (
+                        "as ff0 F".to_owned(),
+                        NodeType::Fixed,
+                        IsZeroExpression::Zero,
+                    )
                 }
             }
             Expression::Fixed(fixed_query) => {
@@ -504,7 +522,11 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                 }
                 let term = format!("(as ff{:?} F)", t);
 
-                (term, NodeType::Fixed)
+                if t == 0 {
+                    is_zero_expression = IsZeroExpression::Zero;
+                }
+
+                (term, NodeType::Fixed, is_zero_expression)
             }
             Expression::Advice(advice_query) => {
                 let term = format!(
@@ -517,11 +539,13 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     t = cell_to_cycle_head[&term.clone()].to_string();
                 }
                 smt::write_var(printer, t.to_string());
-                (t.to_string(), NodeType::Advice)
+                (t.to_string(), NodeType::Advice, is_zero_expression)
             }
-            Expression::Instance(_instance_query) => ("".to_owned(), NodeType::Instance),
+            Expression::Instance(_instance_query) => {
+                ("".to_owned(), NodeType::Instance, is_zero_expression)
+            }
             Expression::Negated(poly) => {
-                let (node_str, node_type) = Self::decompose_expression(
+                let (node_str, node_type, is_zero_expression) = Self::decompose_expression(
                     poly,
                     printer,
                     region_begin,
@@ -531,6 +555,13 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     fixed,
                     cell_to_cycle_head,
                 );
+                if matches!(is_zero_expression, IsZeroExpression::Zero) {
+                    return (
+                        "as ff0 F".to_owned(),
+                        NodeType::Fixed,
+                        IsZeroExpression::Zero,
+                    );
+                }
                 let term = if (matches!(node_type, NodeType::Advice)
                     || matches!(node_type, NodeType::Instance)
                     || matches!(node_type, NodeType::Fixed)
@@ -540,10 +571,10 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                 } else {
                     format!("ff.neg ({})", node_str)
                 };
-                (term, NodeType::Negated)
+                (term, NodeType::Negated,is_zero_expression)
             }
             Expression::Sum(a, b) => {
-                let (node_str_left, nodet_type_left) = Self::decompose_expression(
+                let (node_str_left, nodet_type_left, left_is_zero) = Self::decompose_expression(
                     a,
                     printer,
                     region_begin,
@@ -553,7 +584,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     fixed,
                     cell_to_cycle_head,
                 );
-                let (node_str_right, nodet_type_right) = Self::decompose_expression(
+                let (node_str_right, nodet_type_right, right_is_zero) = Self::decompose_expression(
                     b,
                     printer,
                     region_begin,
@@ -563,6 +594,17 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     fixed,
                     cell_to_cycle_head,
                 );
+
+                if matches!(left_is_zero, IsZeroExpression::Zero)
+                    && matches!(right_is_zero, IsZeroExpression::Zero)
+                {
+                    return (
+                        "as ff0 F".to_owned(),
+                        NodeType::Fixed,
+                        IsZeroExpression::Zero,
+                    );
+                }
+
                 let term = smt::write_term(
                     printer,
                     "add".to_owned(),
@@ -571,10 +613,10 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     node_str_right,
                     nodet_type_right,
                 );
-                (term, NodeType::Add)
+                (term, NodeType::Add, is_zero_expression)
             }
             Expression::Product(a, b) => {
-                let (node_str_left, nodet_type_left) = Self::decompose_expression(
+                let (node_str_left, nodet_type_left, left_is_zero) = Self::decompose_expression(
                     a,
                     printer,
                     region_begin,
@@ -584,7 +626,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     fixed,
                     cell_to_cycle_head,
                 );
-                let (node_str_right, nodet_type_right) = Self::decompose_expression(
+                let (node_str_right, nodet_type_right, right_is_zero) = Self::decompose_expression(
                     b,
                     printer,
                     region_begin,
@@ -594,6 +636,17 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     fixed,
                     cell_to_cycle_head,
                 );
+
+                if matches!(left_is_zero, IsZeroExpression::Zero)
+                    || matches!(right_is_zero, IsZeroExpression::Zero)
+                {
+                    return (
+                        "as ff0 F".to_owned(),
+                        NodeType::Fixed,
+                        IsZeroExpression::Zero,
+                    );
+                }
+
                 let term = smt::write_term(
                     printer,
                     "mul".to_owned(),
@@ -602,11 +655,11 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     node_str_right,
                     nodet_type_right,
                 );
-                (term, NodeType::Mult)
+                (term, NodeType::Mult, is_zero_expression)
             }
             Expression::Scaled(_poly, c) => {
                 // convering the field element into an expression constant and recurse.
-                let (node_str_left, nodet_type_left) = Self::decompose_expression(
+                let (node_str_left, nodet_type_left, lef_is_zero) = Self::decompose_expression(
                     &Expression::Constant(*c),
                     printer,
                     region_begin,
@@ -616,7 +669,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     fixed,
                     cell_to_cycle_head,
                 );
-                let (node_str_right, nodet_type_right) = Self::decompose_expression(
+                let (node_str_right, nodet_type_right, right_is_zero) = Self::decompose_expression(
                     _poly,
                     printer,
                     region_begin,
@@ -626,6 +679,15 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     fixed,
                     cell_to_cycle_head,
                 );
+                if matches!(lef_is_zero, IsZeroExpression::Zero)
+                    || matches!(right_is_zero, IsZeroExpression::Zero)
+                {
+                    return (
+                        "as ff0 F".to_owned(),
+                        NodeType::Fixed,
+                        IsZeroExpression::Zero,
+                    );
+                }
                 let term = smt::write_term(
                     printer,
                     "mul".to_owned(),
@@ -634,14 +696,14 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     node_str_right,
                     nodet_type_right,
                 );
-                (term, NodeType::Scaled)
+                (term, NodeType::Scaled, is_zero_expression)
             }
             #[cfg(any(
                 feature = "use_pse_halo2_proofs",
                 feature = "use_axiom_halo2_proofs",
                 feature = "use_scroll_halo2_proofs"
             ))]
-            Expression::Challenge(_poly) => ("".to_string(), NodeType::Fixed),
+            Expression::Challenge(_poly) => ("".to_string(), NodeType::Fixed, is_zero_expression),
         }
     }
 
@@ -661,7 +723,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                 if es.contains_key(a) {
                     ("(as ff1 F)".to_owned(), NodeType::Fixed, "1".to_owned())
                 } else {
-                    ("(as ff0 F)".to_owned(), NodeType::Fixed, "0".to_owned())
+                    ("as ff0 F".to_owned(), NodeType::Fixed, "0".to_owned())
                 }
             }
             Expression::Fixed(fixed_query) => {
@@ -779,7 +841,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     for row_num in 0..region_end - region_begin + 1 {
                         for gate in self.cs.gates.iter() {
                             for poly in &gate.polys {
-                                let (node_str, _) = Self::decompose_expression(
+                                let (node_str, _, _) = Self::decompose_expression(
                                     poly,
                                     printer,
                                     region_begin,
@@ -804,7 +866,9 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
             }
         }
         // Extract all lookups
-        if (matches!(analyzer_input.lookup_method,LookupMethod::Uninterpreted) || matches!(analyzer_input.lookup_method,LookupMethod::Interpreted)) {
+        if (matches!(analyzer_input.lookup_method, LookupMethod::Uninterpreted)
+            || matches!(analyzer_input.lookup_method, LookupMethod::Interpreted))
+        {
             // Extract all lookups as uninterpreted functions and stores all lookup structure to be use for post-processing
             self.decompose_lookups_as_uniterpreted(printer, analyzer_input)?;
         } else {
@@ -829,7 +893,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                     for lookup in self.cs.lookups.iter() {
                         let mut cons_str_vec = Vec::new();
                         for poly in &lookup.input_expressions {
-                            let (node_str, _) = Self::decompose_expression(
+                            let (node_str, _, _) = Self::decompose_expression(
                                 poly,
                                 printer,
                                 region_begin,
@@ -992,7 +1056,6 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
         printer: &mut smt::Printer<File>,
         analyzer_input: &AnalyzerInput,
     ) -> Result<(), anyhow::Error> {
-
         let mut lookup_func_map = HashMap::new();
         for region in &self.regions {
             if !region.enabled_selectors.is_empty() {
@@ -1030,7 +1093,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                         }
                         let mut function_input = String::new();
                         let mut function_body = String::new();
-                        if matches!(analyzer_input.lookup_method,LookupMethod::Interpreted) {
+                        if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted) {
                             // Extract the lookup dependant cells and write assertions of an uninterpreted function using an SMT printer.
                             let big_cons_str = Self::extract_lookup_constraints_unint(
                                 self,
@@ -1053,7 +1116,8 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 // Keeping track of in the current lookup, which cell is mapped to which column in the lookup table.
                                 lookup_mapping.insert(var.clone(), col_index);
                                 // Conncatinate function_input with format!("(x_{} ", col_index)
-                                if matches!(analyzer_input.lookup_method,LookupMethod::Interpreted) {
+                                if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted)
+                                {
                                     function_input.push_str(&format!("(x_{} F)", input_index));
                                     input_index += 1;
                                 }
@@ -1068,7 +1132,9 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                 format!("isInLookupTable{}", lookup_index);
                             if !lookup_func_map.contains_key(&lookup_index) {
                                 lookup_func_map.insert(lookup_index, true);
-                                if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted){// lookup_interpreted_func {
+                                if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted)
+                                {
+                                    // lookup_interpreted_func {
                                     smt::write_define_fn(
                                         printer,
                                         uninterpreted_func_name.clone(),
@@ -1085,7 +1151,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                     );
                                 }
                             }
-                            if matches!( analyzer_input.lookup_method,LookupMethod::Interpreted) {
+                            if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted) {
                                 // Concatenate all lookup input expressions and write assertions of an uninterpreted function using an SMT printer.
                                 println!("lookup_arg_cells: {:?}", lookup_arg_cells);
                                 let cons_str = lookup_arg_cells
@@ -1103,7 +1169,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                     smt::write_assert_boolean_func(
                                         printer,
                                         uninterpreted_func_name.clone(),
-                                        format!("({})",cons_str).to_owned(),
+                                        format!("({})", cons_str).to_owned(),
                                     );
                                 }
                             }
@@ -1158,7 +1224,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                         }
                         let mut function_input = String::new();
                         let mut function_body = String::new();
-                        if matches!(analyzer_input.lookup_method,LookupMethod::Interpreted) {
+                        if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted) {
                             // Extract the lookup dependant cells and write assertions of an uninterpreted function using an SMT printer.
                             let big_cons_str = Self::extract_lookup_constraints_unint(
                                 self,
@@ -1177,7 +1243,8 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                             }
                             if let Some(&col_index) = col_indices.get(index) {
                                 lookup_mapping.insert(var.clone(), col_index);
-                                if matches!(analyzer_input.lookup_method,LookupMethod::Interpreted) {
+                                if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted)
+                                {
                                     function_input.push_str(&format!("(x_{} F)", input_index));
                                     input_index += 1;
                                 }
@@ -1186,12 +1253,14 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                         if !lookup_mapping.is_empty() {
                             &self.lookup_mappings.push(lookup_mapping.clone());
                         }
-                        if !cons_str_vec.is_empty()  && !lookup_mapping.is_empty() {
+                        if !cons_str_vec.is_empty() && !lookup_mapping.is_empty() {
                             let uninterpreted_func_name =
                                 format!("isInLookupTable{}", lookup_index);
                             if !lookup_func_map.contains_key(&lookup_index) {
                                 lookup_func_map.insert(lookup_index, true);
-                                if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted){// lookup_interpreted_func {
+                                if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted)
+                                {
+                                    // lookup_interpreted_func {
                                     smt::write_define_fn(
                                         printer,
                                         uninterpreted_func_name.clone(),
@@ -1208,7 +1277,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                     );
                                 }
                             }
-                            if matches!( analyzer_input.lookup_method,LookupMethod::Interpreted) {
+                            if matches!(analyzer_input.lookup_method, LookupMethod::Interpreted) {
                                 // Concatenate all lookup input expressions and write assertions of an uninterpreted function using an SMT printer.
                                 let cons_str = lookup_arg_cells
                                     .iter()
@@ -1225,7 +1294,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                                     smt::write_assert_boolean_func(
                                         printer,
                                         uninterpreted_func_name.clone(),
-                                        format!("({})",cons_str).to_owned(),
+                                        format!("({})", cons_str).to_owned(),
                                     );
                                 }
                             }
@@ -1247,7 +1316,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                         let mut cons_str_vec = Vec::new();
                         for polys in &lookup.1.inputs {
                             for poly in polys {
-                                let (node_str, _) = Self::decompose_expression(
+                                let (node_str, _, _) = Self::decompose_expression(
                                     &poly,
                                     printer,
                                     region_begin,
@@ -1399,7 +1468,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                 return Ok(result); // We can just break here.
             }
             // No need to do the lookup as they are already constrained in SMT solver where uninterpreted functions are not used for lookups.
-            if !matches!(analyzer_input.lookup_method,LookupMethod::Uninterpreted){
+            if !matches!(analyzer_input.lookup_method, LookupMethod::Uninterpreted) {
                 info!("Model {} to be checked:", i);
                 for r in &model.result {
                     info!("{} : {}", r.1.name, r.1.value.element)
@@ -1495,7 +1564,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                         .context("Failed to solve and get model!")?;
 
                 // If using uninterpreted function, we need to check if the model is valid by performing the lookup.
-                if matches!(analyzer_input.lookup_method,LookupMethod::Uninterpreted) {
+                if matches!(analyzer_input.lookup_method, LookupMethod::Uninterpreted) {
                     info!("Equivalent model for the same public input!(No Lookup Constraint):");
                     for r in &model_with_constraint.result {
                         info!("{} : {}", r.1.name, r.1.value.element)


### PR DESCRIPTION
This PR interprets constraints added from polynomials in gates and lookups for expressions that are equal to zero. This happens because of disabled selectors. By identifying these expressions we replace them in SMT constraints with zero.  