### PR TITLE
ZKR-3525-Abstract-interpretation-BigInt-Fixed

### DIFF
--- a/korrekt/src/sample_circuits/axiom/bit_decomposition/add_multiplication.rs
+++ b/korrekt/src/sample_circuits/axiom/bit_decomposition/add_multiplication.rs
@@ -107,10 +107,11 @@ impl<F: Field> Circuit<F> for AddMultCircuit<F> {
                 || "test 2",
                 |mut region| {
                     // do mul (into next)
-                    region.assign_advice(config.columns[0], 0, Value::known(self.a));
-                    region.assign_advice(config.columns[1], 0, Value::known(self.b));
+                    // TODO: Investigate axiom region rows handling: ZKR-3636 
+                    region.assign_advice(config.columns[0], 2, Value::known(self.a));
+                    region.assign_advice(config.columns[1], 2, Value::known(self.b));
                     let c = self.a * self.b;
-                    region.assign_advice(config.columns[0], 1, Value::known(c));
+                    region.assign_advice(config.columns[0], 3, Value::known(c));
                     Ok(())
                 },
             )


### PR DESCRIPTION
This PR replaces the `fixed` vector of `CellValues` with its equivalent BigInt version for abstract interpretation.

A bug was fixed in abstract interpretation using incorrect usage of `row_num`.

A TODO added as handling of Offsets in `assign_advice` differs Between Axiom and Other Halo2 Implementations.