### PR TITLE
ZKR-3594-Analysis-Options-Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,19 +102,44 @@ For certain versions, multiple patches may be available. It's important to ensur
 2. Run `cargo run` for the default feature flag (`use_zcash_halo2_proofs`).
 
     ```bash
-    cargo run
+    cargo run -- [OPTIONS]
     ```
 
     For other versions of halo2 run `cargo run` with relevant halo2 version feature flag:
 
     ```bash
-    cargo run --no-default-features --features use_pse_halo2_proofs
-    cargo run --no-default-features --features use_axiom_halo2_proofs
-    cargo run --no-default-features --features use_scroll_halo2_proofs
-    cargo run --no-default-features --features use_pse_v1_halo2_proofs
+    cargo run --no-default-features --features use_pse_halo2_proofs -- [OPTIONS]
+    cargo run --no-default-features --features use_axiom_halo2_proofs -- [OPTIONS]
+    cargo run --no-default-features --features use_scroll_halo2_proofs -- [OPTIONS]
+    cargo run --no-default-features --features use_pse_v1_halo2_proofs -- [OPTIONS]
     ```
 
-   A circuit is hard-coded in main.rs, in the future this should be a library.
+Replace `[OPTIONS]` with the desired options as described below.
+
+### Options
+
+- `-p, --profile <PROFILE>`: Select a predefined configuration profile. Available profiles include:
+  - `specific_inline` (`si`)
+  - `random_inline` (`rin`)
+  - `random_uninterpreted` (`ru`)
+  - `random_interpreted` (`ri`)
+
+- `-t, --type <TYPE>`: Specify the type of analysis to be performed. Available types include:
+  - `unused_gates` (`ug`)
+  - `unused_columns` (`uc`)
+  - `unconstrained_cells` (`ucc`)
+  - `underconstrained_circuit` (`undcc`)
+
+- `-l, --lookup <METHOD>`: Set the lookup method. This option is required for the `underconstrained_circuit` type. Available methods include:
+  - `uninterpreted` (`u`)
+  - `interpreted` (`i`)
+  - `inline` (`in`)
+
+- `-v, --verification <METHOD>`: Specify the verification method. This option is required for the `underconstrained_circuit` type. Available methods include:
+  - `specific` (`s`)
+  - `random` (`r`)
+
+- `-i, --iterations <COUNT>`: Specify the number of iterations for random input verification. This option is only needed if the verification method is set to `random`.
 
 ## How to test
 

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Replace `[OPTIONS]` with the desired options as described below.
 ### Options
 
 - `-p, --profile <PROFILE>`: Select a predefined configuration profile. Available profiles include:
-  - `specific_inline` (`si`)
-  - `random_inline` (`rin`)
-  - `random_uninterpreted` (`ru`)
-  - `random_interpreted` (`ri`)
+  - `specific_inline`
+  - `random_inline`
+  - `random_uninterpreted`
+  - `random_interpreted`
 
 - `-t, --type <TYPE>`: Specify the type of analysis to be performed. Available types include:
   - `unused_gates` (`ug`)

--- a/korrekt/Cargo.toml
+++ b/korrekt/Cargo.toml
@@ -22,6 +22,9 @@ num-bigint = "0.4.4"
 rayon = "1.5.1"
 ff = "0.13"
 group = "0.13"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.5"
+clap = "3.0"
 
 [lib]
 name = "korrekt"

--- a/korrekt/src/circuit_analyzer/analyzer.rs
+++ b/korrekt/src/circuit_analyzer/analyzer.rs
@@ -1931,7 +1931,11 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                         &self.instace_cells,
                     )
                     .context("Failed to retrieve user input!")?;
-                    analyzer_input.verification_input.instances_string = instance;
+                    analyzer_input.verification_input.instances_string = instance.clone();
+                    println!("Instance columns: {:?}", instance);
+                }
+                else {
+                    analyzer_input.verification_input.instances_string = self.instace_cells.clone();
                 }
                 self.analyze_underconstrained(analyzer_input, prime)
             }

--- a/korrekt/src/circuit_analyzer/analyzer.rs
+++ b/korrekt/src/circuit_analyzer/analyzer.rs
@@ -1562,6 +1562,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
             VerificationMethod::Random => {
                 max_iterations = analyzer_input.verification_input.iterations;
             }
+            VerificationMethod::None => {},
         }
         let model = Self::solve_and_get_model(smt_file_path.clone(), &variables)
             .context("Failed to solve and get model!")?;

--- a/korrekt/src/config.rs
+++ b/korrekt/src/config.rs
@@ -1,12 +1,9 @@
-// src/config.rs
-
 use std::collections::HashMap;
+use anyhow::{anyhow, Context, Result};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use anyhow::{Context, Result};
 use crate::io::analyzer_io_type::{AnalyzerInput, AnalyzerType, LookupMethod, VerificationInput, VerificationMethod};
-
 
 impl AnalyzerInput {
     pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -17,57 +14,61 @@ impl AnalyzerInput {
         file.read_to_string(&mut contents)
             .context("Failed to read configuration file")?;
 
-        let config = toml::from_str(&contents)
+        let config: toml::Value = toml::from_str(&contents)
             .context("Failed to parse configuration file")?;
+
+        let analysis_type = config["analyzer_input"]["analysis_type"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Analysis type not found in the configuration"))?;
         
-        Ok(config)
+        let verification_input = VerificationInput {
+            instances_string: HashMap::new(),
+            iterations: config["analyzer_input"]["iterations"]
+                .as_str()
+                .ok_or_else(|| anyhow!("Iterations not found in the configuration"))?
+                .parse::<u128>()
+                .context("Failed to parse iterations as u128")?,
+        };
+
+        let lookup_method = config["analyzer_input"]["lookup_method"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Lookup method not found in the configuration"))?;
+        
+        let verification_method = config["analyzer_input"]["verification_method"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Verification method not found in the configuration"))?;
+        
+        Ok(AnalyzerInput {
+            analysis_type: Self::parse_analysis_type(analysis_type).unwrap(),
+            verification_method: Self::parse_verification_method(verification_method).unwrap(),
+            verification_input,
+            lookup_method: Self::parse_lookup_method(lookup_method).unwrap(),
+        })
+    }
+    fn parse_analysis_type(input: &str) -> Result<AnalyzerType> {
+        match input {
+            "unused_gates" => Ok(AnalyzerType::UnusedGates),
+            "unused_columns" => Ok(AnalyzerType::UnusedColumns),
+            "unconstrained_cells" => Ok(AnalyzerType::UnconstrainedCells),
+            "UnderconstrainedCircuit" => Ok(AnalyzerType::UnderconstrainedCircuit),
+            _ => Err(anyhow::anyhow!("Invalid analysis type")),
+        }
     }
     
-    pub fn specific_inline() -> Self {
-        Self {
-            analysis_type: AnalyzerType::UnderconstrainedCircuit,
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: HashMap::new(), // This would be set by the user
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
+    fn parse_verification_method(input: &str) -> Result<VerificationMethod> {
+        match input {
+            "specific" => Ok(VerificationMethod::Specific),
+            "random" => Ok(VerificationMethod::Random),
+            _ => Err(anyhow::anyhow!("Invalid verification method")),
         }
     }
-
-    pub fn random_inline() -> Self {
-        Self {
-            analysis_type: AnalyzerType::UnderconstrainedCircuit,
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: HashMap::new(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        }
-    }
-
-    pub fn random_uninterpreted() -> Self {
-        Self {
-            analysis_type: AnalyzerType::UnderconstrainedCircuit,
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: HashMap::new(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::Uninterpreted,
-        }
-    }
-
-    pub fn random_interpreted() -> Self {
-        Self {
-            analysis_type: AnalyzerType::UnderconstrainedCircuit,
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: HashMap::new(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::Interpreted,
+    
+    fn parse_lookup_method(input: &str) -> Result<LookupMethod> {
+        match input {
+            "uninterpreted" => Ok(LookupMethod::Uninterpreted),
+            "interpreted" => Ok(LookupMethod::Interpreted),
+            "inline" => Ok(LookupMethod::InlineConstraints),
+            _ => Err(anyhow::anyhow!("Invalid lookup method")),
         }
     }
 }

--- a/korrekt/src/config.rs
+++ b/korrekt/src/config.rs
@@ -1,6 +1,5 @@
 // src/config.rs
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;

--- a/korrekt/src/config.rs
+++ b/korrekt/src/config.rs
@@ -22,21 +22,8 @@ impl AnalyzerInput {
         
         Ok(config)
     }
-    // Default configuration for general use
-    pub fn default() -> Self {
-        Self {
-            analysis_type: AnalyzerType::UnderconstrainedCircuit,
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: HashMap::new(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        }
-    }
-
-    // Specific predefined configurations for typical use cases
-    pub fn specific_public_input_inline_lookup() -> Self {
+    
+    pub fn specific_inline() -> Self {
         Self {
             analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
@@ -48,7 +35,7 @@ impl AnalyzerInput {
         }
     }
 
-    pub fn random_public_input_five_iterations_inline_lookup() -> Self {
+    pub fn random_inline() -> Self {
         Self {
             analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
@@ -60,7 +47,7 @@ impl AnalyzerInput {
         }
     }
 
-    pub fn random_public_input_five_iterations_uninterpreted_lookup() -> Self {
+    pub fn random_uninterpreted() -> Self {
         Self {
             analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
@@ -72,7 +59,7 @@ impl AnalyzerInput {
         }
     }
 
-    pub fn random_public_input_five_iterations_interpreted_lookup() -> Self {
+    pub fn random_interpreted() -> Self {
         Self {
             analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,

--- a/korrekt/src/config.rs
+++ b/korrekt/src/config.rs
@@ -1,0 +1,87 @@
+// src/config.rs
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use anyhow::{Context, Result};
+use crate::io::analyzer_io_type::{AnalyzerInput, AnalyzerType, LookupMethod, VerificationInput, VerificationMethod};
+
+
+impl AnalyzerInput {
+    pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let mut file = File::open(path)
+            .context("Failed to open configuration file")?;
+        
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .context("Failed to read configuration file")?;
+
+        let config = toml::from_str(&contents)
+            .context("Failed to parse configuration file")?;
+        
+        Ok(config)
+    }
+    // Default configuration for general use
+    pub fn default() -> Self {
+        Self {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: HashMap::new(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        }
+    }
+
+    // Specific predefined configurations for typical use cases
+    pub fn specific_public_input_inline_lookup() -> Self {
+        Self {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: HashMap::new(), // This would be set by the user
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        }
+    }
+
+    pub fn random_public_input_five_iterations_inline_lookup() -> Self {
+        Self {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: HashMap::new(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        }
+    }
+
+    pub fn random_public_input_five_iterations_uninterpreted_lookup() -> Self {
+        Self {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: HashMap::new(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::Uninterpreted,
+        }
+    }
+
+    pub fn random_public_input_five_iterations_interpreted_lookup() -> Self {
+        Self {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: HashMap::new(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::Interpreted,
+        }
+    }
+}

--- a/korrekt/src/config/random_inline.toml
+++ b/korrekt/src/config/random_inline.toml
@@ -1,0 +1,5 @@
+[analyzer_input]
+analysis_type = "UnderconstrainedCircuit"
+verification_method = "random"
+iterations = "5"
+lookup_method = "inline"

--- a/korrekt/src/config/random_interpreted.toml
+++ b/korrekt/src/config/random_interpreted.toml
@@ -1,0 +1,5 @@
+[analyzer_input]
+analysis_type = "UnderconstrainedCircuit"
+verification_method = "random"
+iterations = "5"
+lookup_method = "interpreted"

--- a/korrekt/src/config/random_uninterpreted.toml
+++ b/korrekt/src/config/random_uninterpreted.toml
@@ -1,0 +1,5 @@
+[analyzer_input]
+analysis_type = "UnderconstrainedCircuit"
+verification_method = "random"
+iterations = "5"
+lookup_method = "uninterpreted"

--- a/korrekt/src/config/specific_inline.toml
+++ b/korrekt/src/config/specific_inline.toml
@@ -1,0 +1,5 @@
+[analyzer_input]
+analysis_type = "UnderconstrainedCircuit"
+verification_method = "specific"
+iterations = "1"
+lookup_method = "inline"

--- a/korrekt/src/io/analyzer_io.rs
+++ b/korrekt/src/io/analyzer_io.rs
@@ -55,6 +55,7 @@ pub fn output_result(analyzer_input: &AnalyzerInput, analyzer_output: &AnalyzerO
                         analyzer_input.verification_input.iterations
                     );
                 }
+                VerificationMethod::None => {},
             }
         }
         
@@ -72,6 +73,7 @@ pub fn output_result(analyzer_input: &AnalyzerInput, analyzer_output: &AnalyzerO
                         analyzer_input.verification_input.iterations
                     );
                 }
+                VerificationMethod::None => {},
             }
         }
         AnalyzerOutputStatus::UnusedCustomGates => {}
@@ -96,6 +98,7 @@ pub fn output_result(analyzer_input: &AnalyzerInput, analyzer_output: &AnalyzerO
                         analyzer_input.verification_input.iterations
                     );
                 }
+                VerificationMethod::None => {},
             }
         },
     }

--- a/korrekt/src/io/analyzer_io.rs
+++ b/korrekt/src/io/analyzer_io.rs
@@ -12,80 +12,11 @@ use crate::{
 /// or a random number of public inputs. It then collects the necessary user input based on the chosen
 /// verification type and constructs an `AnalyzerInput` struct to be used in the underconstrained analysis.
 ///
-pub fn retrieve_user_input_for_underconstrained<F: AnalyzableField>(
-    instance_cols_string: &HashMap<String, i64>,
-    cs: &ConstraintSystem<F>,
-) -> Result<AnalyzerInput> {
-    let mut lookup_method = LookupMethod::InlineConstraints;
+pub fn retrieve_user_input_for_underconstrained<F: AnalyzableField>(input: &AnalyzerInput,instance_cols_string: &HashMap<String, i64>) -> Result<HashMap<String, i64>> {
 
-    let mut has_lookup = false;
-    #[cfg(any(
-        feature = "use_zcash_halo2_proofs",
-        feature = "use_pse_halo2_proofs",
-        feature = "use_axiom_halo2_proofs",
-        feature = "use_pse_v1_halo2_proofs",
-    ))]
-    if !cs.lookups.is_empty() {
-        has_lookup = true;
-    }
 
-    #[cfg(feature = "use_scroll_halo2_proofs")]
-    if !cs.lookups_map.is_empty() {
-        has_lookup = true;
-    }
-
-    if has_lookup {
-        println!("You can use uninterpreted functions for lookup analysis for fast analysis at the cost of potential false positives, or use range check functions instead of inline constraints:");
-        println!("1. Verify the circuit with uninterpreted functions for lookups!");
-        println!("2. Verify the circuit with all lookup constraints!");
-        println!("3. Verify the circuit with interpreted functions (Range Check) for lookups!");
-        let mut menu = String::new();
-        io::stdin()
-            .read_line(&mut menu)
-            .expect("Failed to read line");
-
-        let selection = menu
-            .trim()
-            .parse::<i32>() // Using i32 assuming the options are small integer values
-            .expect("Failed to parse input as integer"); // Simplifying error handling for example
-
-        // Setting lookup_uninterpreted_func based on selected option
-        lookup_method = match selection {
-            1 => LookupMethod::Uninterpreted,
-            2 => LookupMethod::InlineConstraints,
-            3 => LookupMethod::Interpreted,
-            _ => {
-                println!("Invalid selection, defaulting to 'false'");
-                LookupMethod::Invalid
-            }
-        };
-    }
-    println!("You can verify the circuit for a specific public input or a random number of public inputs:");
-    println!("1. verify the circuit for a specific public input!");
-    println!("2. Verify for a random number of public inputs!");
-
-    let mut menu = String::new();
-    const SPECIFIC: i64 = 1;
-    const RANDOM: i64 = 2;
-    io::stdin()
-        .read_line(&mut menu)
-        .expect("Failed to read line");
-    let verification_type = menu
-        .trim()
-        .parse::<i64>()
-        .context("Failed to retrieve verification type!")?;
-
-    let mut analyzer_input: AnalyzerInput = AnalyzerInput {
-        verification_method: VerificationMethod::Random,
-        verification_input: VerificationInput {
-            iterations: 1,
-            instances_string: HashMap::new(),
-        },
-        lookup_method
-    };
-
-    match verification_type {
-        SPECIFIC => {
+    match input.verification_method {
+        VerificationMethod::Specific => {
             let mut specified_instance_cols_string: HashMap<String, i64> = HashMap::new();
 
             for var in instance_cols_string.iter() {
@@ -97,29 +28,9 @@ pub fn retrieve_user_input_for_underconstrained<F: AnalyzableField>(
                 specified_instance_cols_string
                     .insert(var.0.clone(), input_var.trim().parse::<i64>()?);
             }
-
-            analyzer_input.verification_method = VerificationMethod::Specific;
-            analyzer_input.verification_input.instances_string = specified_instance_cols_string;
-            Ok(analyzer_input)
+            Ok(specified_instance_cols_string)
         }
-        RANDOM => {
-            let mut input_var = String::new();
-
-            println!("How many random public inputs you want to verify?");
-            io::stdin()
-                .read_line(&mut input_var)
-                .expect("Failed to read line");
-
-            let iterations = input_var
-                .trim()
-                .parse::<u128>()
-                .context("Failed to retrieve number of iterations!")?;
-            analyzer_input.verification_method = VerificationMethod::Random;
-            analyzer_input.verification_input.instances_string = instance_cols_string.clone();
-            analyzer_input.verification_input.iterations = iterations;
-            Ok(analyzer_input)
-        }
-        _ => Err(anyhow!("Option {} Is Invalid", verification_type)),
+        _ => Err(anyhow!("Option Is Invalid")),
     }
 }
 /// Outputs the result of the analysis.
@@ -127,14 +38,26 @@ pub fn retrieve_user_input_for_underconstrained<F: AnalyzableField>(
 /// This function takes an `AnalyzerInput` and `AnalyzerOutput` as input and prints the corresponding
 /// result message based on the `AnalyzerOutputStatus` in the `AnalyzerOutput` struct.
 ///
-pub fn output_result(analyzer_input: AnalyzerInput, analyzer_output: &AnalyzerOutput) {
+pub fn output_result(analyzer_input: &AnalyzerInput, analyzer_output: &AnalyzerOutput) {
     match analyzer_output.output_status {
         AnalyzerOutputStatus::Underconstrained => {
             println!("The circuit is under-constrained.");
         }
-        AnalyzerOutputStatus::Overconstrained => {
-            println!("The circuit is over-constrained");
+        AnalyzerOutputStatus::Overconstrained => 
+        {
+            match analyzer_input.verification_method {
+                VerificationMethod::Specific => {
+                    println!("The circuit is over-constrained for this specific input.");
+                }
+                VerificationMethod::Random => {
+                    println!(
+                        "The circuit is over-constrained for {} random input(s).",
+                        analyzer_input.verification_input.iterations
+                    );
+                }
+            }
         }
+        
         AnalyzerOutputStatus::NotUnderconstrained => {
             println!("The circuit is not under-constrained!");
         }

--- a/korrekt/src/io/analyzer_io_type.rs
+++ b/korrekt/src/io/analyzer_io_type.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum VerificationMethod {
     Specific,
     Random,
+    None
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -18,7 +19,7 @@ pub enum LookupMethod {
     Uninterpreted,
     Interpreted,
     InlineConstraints,
-    Invalid
+    None
 }
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AnalyzerInput {

--- a/korrekt/src/io/analyzer_io_type.rs
+++ b/korrekt/src/io/analyzer_io_type.rs
@@ -1,24 +1,28 @@
 use std::collections::HashMap;
-#[derive(Debug, PartialEq, Eq)]
+
+use serde::{Deserialize, Serialize};
+// #[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 pub enum VerificationMethod {
     Specific,
     Random,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct VerificationInput {
     pub instances_string: HashMap<String, i64>,
     pub iterations: u128,
 }
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 pub enum LookupMethod {
     Uninterpreted,
     Interpreted,
     InlineConstraints,
     Invalid
 }
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AnalyzerInput {
+    pub analysis_type: AnalyzerType,
     pub verification_method: VerificationMethod,
     pub verification_input: VerificationInput,
     pub lookup_method: LookupMethod
@@ -45,7 +49,7 @@ pub struct AnalyzerOutput {
     pub output_status: AnalyzerOutputStatus,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum AnalyzerType {
     UnusedGates,
     UnconstrainedCells,

--- a/korrekt/src/io/analyzer_io_type.rs
+++ b/korrekt/src/io/analyzer_io_type.rs
@@ -1,27 +1,25 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
-// #[derive(Debug, PartialEq, Eq)]
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone,Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum VerificationMethod {
     Specific,
     Random,
     None
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct VerificationInput {
     pub instances_string: HashMap<String, i64>,
     pub iterations: u128,
 }
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone,Copy)]
+#[derive(Debug, PartialEq, Eq,Clone,Copy)]
 pub enum LookupMethod {
     Uninterpreted,
     Interpreted,
     InlineConstraints,
     None
 }
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct AnalyzerInput {
     pub analysis_type: AnalyzerType,
     pub verification_method: VerificationMethod,
@@ -50,7 +48,7 @@ pub struct AnalyzerOutput {
     pub output_status: AnalyzerOutputStatus,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub enum AnalyzerType {
     UnusedGates,
     UnconstrainedCells,

--- a/korrekt/src/io/analyzer_io_type.rs
+++ b/korrekt/src/io/analyzer_io_type.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 // #[derive(Debug, PartialEq, Eq)]
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone,Copy)]
 pub enum VerificationMethod {
     Specific,
     Random,
@@ -13,7 +13,7 @@ pub struct VerificationInput {
     pub instances_string: HashMap<String, i64>,
     pub iterations: u128,
 }
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone,Copy)]
 pub enum LookupMethod {
     Uninterpreted,
     Interpreted,

--- a/korrekt/src/lib.rs
+++ b/korrekt/src/lib.rs
@@ -3,3 +3,4 @@ pub mod io;
 pub mod sample_circuits;
 pub mod smt_solver;
 pub mod test;
+pub mod config;

--- a/korrekt/src/main.rs
+++ b/korrekt/src/main.rs
@@ -110,11 +110,9 @@ fn main() -> Result<()> {
     Ok(())
 }
 fn load_config_for_profile(profile: &str) -> Result<AnalyzerInput> {
-
     let config_path = format!("./src/config/{}.toml", profile);
-
     AnalyzerInput::load_config(Path::new(&config_path))
-        
+    .with_context(|| format!("Failed to load configuration for profile: {}", profile))
 }
 fn parse_lookup_method(input: &str) -> LookupMethod {
     match input {

--- a/korrekt/src/main.rs
+++ b/korrekt/src/main.rs
@@ -39,8 +39,8 @@ fn main() -> Result<()> {
             .short('p')
             .long("profile")
             .takes_value(true)
-            .help("Select a predefined configuration profile: default (d), specific_public_input (spi), random_public_input_five_iterations (rpi5), random_uninterpreted (ru), random_interpreted (ri)")
-            .possible_values(&["default", "d", "specific_public_input", "spi", "random_public_input_five_iterations", "rpi5", "random_uninterpreted", "ru", "random_interpreted", "ri"])
+            .help("Select a predefined configuration profile: specific_inline (si), random_inline (ri), random_uninterpreted (ru), random_interpreted (ri)")
+            .possible_values(&["specific_inline", "si", "random_inline", "rin", "random_uninterpreted", "ru", "random_interpreted", "ri"])
             .conflicts_with_all(&["lookup", "iterations", "type", "verification"]))
         .arg(Arg::new("type")
             .short('t')
@@ -73,16 +73,15 @@ fn main() -> Result<()> {
 
     let mut config = if let Some(profile) = matches.value_of("profile") {
         match profile {
-            "default" => AnalyzerInput::default(),
-            "specific_public_input" => AnalyzerInput::specific_public_input_inline_lookup(),
-            "random_public_input_five_iterations" => {
-                AnalyzerInput::random_public_input_five_iterations_inline_lookup()
+            "specific_inline" | "si" => AnalyzerInput::specific_inline(),
+            "random_inline" | "rin" => {
+                AnalyzerInput::random_inline()
             }
-            "random_uninterpreted" => {
-                AnalyzerInput::random_public_input_five_iterations_uninterpreted_lookup()
+            "random_uninterpreted" | "ru" => {
+                AnalyzerInput::random_uninterpreted()
             }
-            "random_interpreted" => {
-                AnalyzerInput::random_public_input_five_iterations_interpreted_lookup()
+            "random_interpreted" | "ri"=> {
+                AnalyzerInput::random_interpreted()
             }
             _ => return Err(anyhow::anyhow!("Invalid configuration profile selected")),
         }

--- a/korrekt/src/main.rs
+++ b/korrekt/src/main.rs
@@ -199,7 +199,7 @@ fn setup_analyzer(
     })
 }
 
-fn run_analysis(input: &mut AnalyzerInput) -> anyhow::Result<()> {
+fn run_analysis(analyzer_input: &mut AnalyzerInput) -> anyhow::Result<()> {
     let circuit = sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
     let k = 6;
 
@@ -212,7 +212,7 @@ fn run_analysis(input: &mut AnalyzerInput) -> anyhow::Result<()> {
         .to_string();
 
     analyzer
-        .dispatch_analysis(input, &prime)
+        .dispatch_analysis(analyzer_input, &prime)
         .context("Failed to perform analysis!")?;
     Ok(())
 }

--- a/korrekt/src/main.rs
+++ b/korrekt/src/main.rs
@@ -1,3 +1,4 @@
+use clap::{App, Arg};
 #[cfg(feature = "use_axiom_halo2_proofs")]
 use korrekt::sample_circuits::axiom as sample_circuits;
 #[cfg(feature = "use_pse_halo2_proofs")]
@@ -8,25 +9,156 @@ use korrekt::sample_circuits::pse_v1 as sample_circuits;
 use korrekt::sample_circuits::scroll as sample_circuits;
 #[cfg(feature = "use_zcash_halo2_proofs")]
 use korrekt::sample_circuits::zcash as sample_circuits;
-use std::marker::PhantomData;
+use std::{collections::HashMap, marker::PhantomData};
 
 use crate::circuit_analyzer::halo2_proofs_libs::*;
 
-use anyhow::{Context, Ok, Result};
+use anyhow::{Context, Ok};
 use korrekt::{
     circuit_analyzer::{self, analyzer::Analyzer},
-    io,
+    io::analyzer_io_type::{
+        AnalyzerInput, AnalyzerType, LookupMethod, VerificationInput, VerificationMethod,
+    },
 };
 use num::{BigInt, Num};
 extern crate env_logger;
 extern crate log;
 
 use env_logger::Env;
-fn main() -> Result<(), anyhow::Error> {
+
+use anyhow::Result;
+use korrekt::circuit_analyzer::halo2_proofs_libs::*;
+use log::{info, warn};
+
+fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
-    let circuit =
-        sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+    let matches = App::new("Circuit Analyzer")
+        .version("1.0")
+        .author("Your Name <your_email@example.com>")
+        .about("Analyzes circuits using different parameters and methods")
+        .arg(Arg::new("profile")
+        .short('p')
+        .long("profile")
+        .takes_value(true)
+        .help("Select a predefined configuration profile: default, specific_public_input, random_public_input_five_iterations, random_uninterpreted, random_interpreted"))
+        .arg(Arg::new("lookup")
+            .short('l')
+            .long("lookup")
+            .takes_value(true)
+            .help("Sets the lookup method: uninterpreted, interpreted, inline"))
+        .arg(Arg::new("iterations")
+            .short('i')
+            .long("iterations")
+            .takes_value(true)
+            .help("Number of iterations for random input verification"))
+        .arg(Arg::new("type")
+            .short('t')
+            .long("type")
+            .takes_value(true)
+            .help("Type of analysis: unused_gates, unused_columns, unconstrained_cells, underconstrained_circuit"))
+        .arg(Arg::new("verification")
+            .short('v')
+            .long("verification")
+            .takes_value(true)
+            .help("Verification method: specific or random"))
+        .get_matches();
+
+    let mut config = if let Some(profile) = matches.value_of("profile") {
+        match profile {
+            "default" => AnalyzerInput::default(),
+            "specific_public_input" => AnalyzerInput::specific_public_input_inline_lookup(),
+            "random_public_input_five_iterations" => {
+                AnalyzerInput::random_public_input_five_iterations_inline_lookup()
+            }
+            "random_uninterpreted" => {
+                AnalyzerInput::random_public_input_five_iterations_uninterpreted_lookup()
+            }
+            "random_interpreted" => {
+                AnalyzerInput::random_public_input_five_iterations_interpreted_lookup()
+            }
+            _ => return Err(anyhow::anyhow!("Invalid configuration profile selected")),
+        }
+    } else {
+        let lookup_method = parse_lookup_method(matches.value_of("lookup"));
+        let iterations = matches
+            .value_of("iterations")
+            .unwrap_or("1")
+            .parse::<u128>()
+            .unwrap_or(1);
+        let analysis_type = parse_analysis_type(matches.value_of("type"));
+        let verification_method = parse_verification_method(matches.value_of("verification"));
+
+        let analyzer_input = setup_analyzer(
+            lookup_method,
+            iterations,
+            analysis_type,
+            verification_method,
+        )?;
+        analyzer_input
+    };
+
+    run_analysis(&mut config)?;
+
+    Ok(())
+}
+
+fn parse_lookup_method(input: Option<&str>) -> LookupMethod {
+    match input {
+        Some("uninterpreted") => LookupMethod::Uninterpreted,
+        Some("interpreted") => LookupMethod::Interpreted,
+        Some("inline") => LookupMethod::InlineConstraints,
+        _ => {
+            warn!("No lookup method provided, defaulting to 'InlineConstraints'");
+            LookupMethod::InlineConstraints
+        }
+    }
+}
+
+fn parse_analysis_type(input: Option<&str>) -> AnalyzerType {
+    match input {
+        Some("unused_gates") => AnalyzerType::UnusedGates,
+        Some("unused_columns") => AnalyzerType::UnusedColumns,
+        Some("unconstrained_cells") => AnalyzerType::UnconstrainedCells,
+        Some("underconstrained_circuit") => AnalyzerType::UnderconstrainedCircuit,
+        _ => {
+            warn!("No analysis type specified, defaulting to 'UnderconstrainedCircuit'");
+            AnalyzerType::UnderconstrainedCircuit
+        }
+    }
+}
+
+fn parse_verification_method(input: Option<&str>) -> VerificationMethod {
+    match input {
+        Some("specific") => VerificationMethod::Specific,
+        Some("random") => VerificationMethod::Random,
+        _ => {
+            warn!("No verification method specified, using 'Random' as default");
+            VerificationMethod::Random
+        }
+    }
+}
+
+fn setup_analyzer(
+    lookup_method: LookupMethod,
+    iterations: u128,
+    analysis_type: AnalyzerType,
+    verification_method: VerificationMethod,
+) -> anyhow::Result<AnalyzerInput> {
+    info!("Setting up analyzer with LookupMethod: {:?}, Iterations: {}, AnalysisType: {:?}, VerificationMethod: {:?}", lookup_method, iterations, analysis_type, verification_method);
+    Ok(AnalyzerInput {
+        analysis_type,
+        verification_method,
+        verification_input: VerificationInput {
+            instances_string: HashMap::new(),
+            iterations,
+        },
+        lookup_method,
+    })
+}
+
+fn run_analysis(input: &mut AnalyzerInput) -> anyhow::Result<()> {
+    let circuit = sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
     let k = 6;
 
     let mut analyzer = Analyzer::new(&circuit, k).unwrap();
@@ -37,12 +169,8 @@ fn main() -> Result<(), anyhow::Error> {
         .unwrap()
         .to_string();
 
-    let analyzer_type = io::analyzer_io::retrieve_user_input_for_analyzer_type()
-        .context("Failed to retrieve the user inputs!")?;
-
     analyzer
-        .dispatch_analysis(analyzer_type, &prime)
+        .dispatch_analysis(input, &prime)
         .context("Failed to perform analysis!")?;
-    //println!(": {:?}", analyzer.fixed);
     Ok(())
 }

--- a/korrekt/src/test/integration_tests_axiom.rs
+++ b/korrekt/src/test/integration_tests_axiom.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "use_axiom_halo2_proofs")]
 mod tests {
     use crate::circuit_analyzer::analyzer::Analyzer;
-    use crate::io::analyzer_io_type::LookupMethod;
+    use crate::io::analyzer_io_type::{AnalyzerType, LookupMethod};
     use crate::io::{
         analyzer_io_type,
         analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
@@ -54,6 +54,7 @@ mod tests {
 
         assert!(analyzer.instace_cells.len().eq(&1));
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells,
@@ -85,6 +86,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -93,7 +95,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
@@ -116,6 +118,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -125,7 +128,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -148,6 +151,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -157,7 +161,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -185,6 +189,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -194,7 +199,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -222,6 +227,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -231,7 +237,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -254,6 +260,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -263,7 +270,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -287,6 +294,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -296,7 +304,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -325,6 +333,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -334,7 +343,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -363,6 +372,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -372,7 +382,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -439,6 +449,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -448,7 +459,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         println!("output_status: {:?}", output_status);
@@ -470,6 +481,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -478,7 +490,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -500,6 +512,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -508,7 +521,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -530,6 +543,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -538,7 +552,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -559,6 +573,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -567,7 +582,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -588,6 +603,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -596,7 +612,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -617,6 +633,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -625,7 +642,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -651,6 +668,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -659,7 +677,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -685,6 +703,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -693,7 +712,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -719,6 +738,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -727,7 +747,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));

--- a/korrekt/src/test/integration_tests_pse.rs
+++ b/korrekt/src/test/integration_tests_pse.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "use_pse_halo2_proofs")]
 mod tests {
     use crate::circuit_analyzer::analyzer::Analyzer;
-    use crate::io::analyzer_io_type::LookupMethod;
+    use crate::io::analyzer_io_type::{AnalyzerType, LookupMethod};
     use crate::io::{
         analyzer_io_type,
         analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
@@ -54,6 +54,7 @@ mod tests {
 
         assert!(analyzer.instace_cells.len().eq(&1));
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells,
@@ -85,6 +86,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -93,7 +95,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
@@ -116,6 +118,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -125,7 +128,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -148,6 +151,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -157,7 +161,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -185,6 +189,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -194,7 +199,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -222,6 +227,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -231,7 +237,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -254,6 +260,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -263,7 +270,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -287,6 +294,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -296,7 +304,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -325,6 +333,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -334,7 +343,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -363,6 +372,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -372,7 +382,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -438,6 +448,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -447,7 +458,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         println!("output_status: {:?}", output_status);
@@ -468,6 +479,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -477,7 +489,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         println!("output_status: {:?}", output_status);
@@ -499,6 +511,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -507,7 +520,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -529,6 +542,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -537,7 +551,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -559,6 +573,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -567,7 +582,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -588,6 +603,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -596,7 +612,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -617,6 +633,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -625,7 +642,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -646,6 +663,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -654,7 +672,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -680,6 +698,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -688,7 +707,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -714,6 +733,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -722,7 +742,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -748,6 +768,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -756,7 +777,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));

--- a/korrekt/src/test/integration_tests_pse_v1.rs
+++ b/korrekt/src/test/integration_tests_pse_v1.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "use_pse_v1_halo2_proofs")]
 mod tests {
     use crate::circuit_analyzer::analyzer::Analyzer;
-    use crate::io::analyzer_io_type::LookupMethod;
+    use crate::io::analyzer_io_type::{AnalyzerType, LookupMethod};
     use crate::io::{
         analyzer_io_type,
         analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
@@ -51,6 +51,7 @@ mod tests {
 
         assert!(analyzer.instace_cells.len().eq(&1));
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells,
@@ -82,6 +83,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -90,7 +92,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
@@ -113,6 +115,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -122,7 +125,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -145,6 +148,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -154,7 +158,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -182,6 +186,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -191,7 +196,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -219,6 +224,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -228,7 +234,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -251,6 +257,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -260,7 +267,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -284,6 +291,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -293,7 +301,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -322,6 +330,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -331,7 +340,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -360,6 +369,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -369,7 +379,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -435,6 +445,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -444,7 +455,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         println!("output_status: {:?}", output_status);
@@ -467,6 +478,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -475,7 +487,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -497,6 +509,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -505,7 +518,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -526,6 +539,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -534,7 +548,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -555,6 +569,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -563,7 +578,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -589,6 +604,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -597,7 +613,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -623,6 +639,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -631,7 +648,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -657,6 +674,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -665,7 +683,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));

--- a/korrekt/src/test/integration_tests_scroll.rs
+++ b/korrekt/src/test/integration_tests_scroll.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "use_scroll_halo2_proofs")]
 mod tests {
     use crate::circuit_analyzer::analyzer::Analyzer;
-    use crate::io::analyzer_io_type::LookupMethod;
+    use crate::io::analyzer_io_type::{AnalyzerType, LookupMethod};
     use crate::io::{
         analyzer_io_type,
         analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
@@ -54,6 +54,7 @@ mod tests {
 
         assert!(analyzer.instace_cells.len().eq(&1));
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells,
@@ -85,6 +86,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -93,7 +95,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
@@ -116,6 +118,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -125,7 +128,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -148,6 +151,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -157,7 +161,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -185,6 +189,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -194,7 +199,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -222,6 +227,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -231,7 +237,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
@@ -254,6 +260,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -263,7 +270,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -287,6 +294,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -296,7 +304,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -325,6 +333,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -334,7 +343,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -363,6 +372,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -372,7 +382,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -438,6 +448,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -447,7 +458,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         println!("output_status: {:?}", output_status);
@@ -468,6 +479,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -477,7 +489,7 @@ mod tests {
         };
 
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         println!("output_status: {:?}", output_status);
@@ -499,6 +511,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -507,7 +520,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -528,6 +541,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -536,7 +550,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
@@ -557,6 +571,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -565,7 +580,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -586,6 +601,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -594,7 +610,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
@@ -615,6 +631,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -623,7 +640,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
@@ -649,6 +666,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -657,7 +675,7 @@ mod tests {
             lookup_method: LookupMethod::Uninterpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
@@ -683,6 +701,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -691,7 +710,7 @@ mod tests {
             lookup_method: LookupMethod::Interpreted,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Overconstrained));
@@ -717,6 +736,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -725,7 +745,7 @@ mod tests {
             lookup_method: LookupMethod::InlineConstraints,
         };
         let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
+            .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
         assert!(output_status.eq(&AnalyzerOutputStatus::Overconstrained));

--- a/korrekt/src/test/integration_tests_zcash.rs
+++ b/korrekt/src/test/integration_tests_zcash.rs
@@ -1,798 +1,820 @@
-// #[cfg(test)]
-// #[cfg(feature = "use_zcash_halo2_proofs")]
-// mod tests {
-//     use crate::circuit_analyzer::analyzer::Analyzer;
-//     use crate::io::analyzer_io_type::LookupMethod;
-//     use crate::io::{
-//         analyzer_io_type,
-//         analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
-//     };
-//     use crate::sample_circuits::zcash as sample_circuits;
-//     use halo2curves::bn256;
-//     use zcash_halo2_proofs::pasta::Fp as Fr;
-
-//     use num::{BigInt, Num};
-//     use std::collections::HashMap;
-//     use std::marker::PhantomData;
-//     use ff::PrimeField;
-
-//     #[test]
-//     fn create_zcash_analyzer_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.cs.gates.len().eq(&3));
-//         assert!(analyzer.cs.degree().eq(&3));
-//         //assert!(analyzer.cs.num_advice_columns().eq(&3));
-//         //assert!(analyzer.cs.num_instance_columns().eq(&1));
-//         //assert!(analyzer.cs.num_selectors.eq(&1) || analyzer.cs.num_fixed_columns().eq(&1));
-//     }
-
-//     #[test]
-//     fn extract_instance_cols_zcash_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let analyzer = Analyzer::new(&circuit, k).unwrap();
-//         assert!(analyzer.instace_cells.len().eq(&1));
-//         assert!(analyzer.instace_cells.contains_key("I-0-0"));
-//         assert!(analyzer.instace_cells.iter().next().unwrap().1.eq(&0));
-//     }
-
-//     #[test]
-//     fn set_user_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&1));
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells,
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-//         assert!(analyzer_input
-//             .verification_method
-//             .eq(&VerificationMethod::Random));
-//         assert!(analyzer_input.verification_input.iterations.eq(&5));
-//     }
-
-//     #[test]
-//     fn simple_test() {
-//         let circuit =
-//             sample_circuits::simple::mul::MulCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 3;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.clone().len().eq(&2));
-
-//         let modulus = Fr::MODULUS;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-
-//     #[test]
-//     fn not_under_constrained_enough_random_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.clone().len().eq(&1));
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
-//     }
-
-//     #[test]
-//     fn not_under_constrained_not_enough_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.clone().len().eq(&1));
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-
-//     #[test]
-//     fn not_under_constrained_not_enough_input_1_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.clone().len().eq(&1));
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 4,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-
-//     #[test]
-//     fn not_under_constrained_exact_spec_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&1));
-//         let mut specified_instance_cols = HashMap::new();
-//         for var in analyzer.instace_cells.iter() {
-//             specified_instance_cols.insert(var.0.clone(), 3);
-//         }
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Specific,
-//             verification_input: VerificationInput {
-//                 instances_string: specified_instance_cols,
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-
-//     #[test]
-//     fn not_under_constrained_not_exact_spec_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-//             );
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&1));
-//         let mut specified_instance_cols = HashMap::new();
-//         for var in analyzer.instace_cells.iter() {
-//             specified_instance_cols.insert(var.0.clone(), 1);
-//         }
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Specific,
-//             verification_input: VerificationInput {
-//                 instances_string: specified_instance_cols,
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-
-//     #[test]
-//     fn under_constrained_enough_random_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-//                 Fr,
-//             >::default();
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-//         assert!(analyzer.instace_cells.clone().len().eq(&1));
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-//     }
-
-//     #[test]
-//     fn under_constrained_not_enough_random_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-//                 Fr,
-//             >::default();
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.clone().len().eq(&1));
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-//     }
-
-//     #[test]
-//     fn under_constrained_exact_spec_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-//                 Fr,
-//             >::default();
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&1));
-//         let mut specified_instance_cols = HashMap::new();
-//         for var in analyzer.instace_cells.iter() {
-//             specified_instance_cols.insert(var.0.clone(), 3);
-//         }
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Specific,
-//             verification_input: VerificationInput {
-//                 instances_string: specified_instance_cols,
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-//     }
-
-//     #[test]
-//     fn under_constrained_not_exact_spec_input_test() {
-//         let circuit =
-//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-//                 Fr,
-//             >::default();
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&1));
-//         let mut specified_instance_cols = HashMap::new();
-//         for var in analyzer.instace_cells.iter() {
-//             specified_instance_cols.insert(var.0.clone(), 1);
-//         }
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Specific,
-//             verification_input: VerificationInput {
-//                 instances_string: specified_instance_cols,
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-//     }
-
-//     #[test]
-//     fn analyze_unused_columns_test() {
-//         let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
-//             sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
-//         let k = 5;
-
-//         //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-//         let output_status = analyzer.analyze_unused_columns().unwrap().output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::UnusedColumns));
-//         assert!(analyzer.log().len().gt(&0))
-//     }
-
-//     #[test]
-//     fn analyze_unused_custom_gates_test() {
-//         let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
-//             sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
-//         let k = 5;
-
-//         //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-//         let output_status = analyzer
-//             .analyze_unused_custom_gates()
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::UnusedCustomGates));
-//         assert!(analyzer.log().len().gt(&0))
-//     }
-
-//     #[test]
-//     fn analyze_unconstrained_cells() {
-//         let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
-//             sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
-//         let k = 5;
-
-//         //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-//         let output_status = analyzer
-//             .analyze_unconstrained_cells()
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::UnconstrainedCells));
-//         assert!(analyzer.log().len().gt(&0))
-//     }
-
-//     #[test]
-//     fn analyze_underconstrained_fibonacci_test() {
-//         let circuit: sample_circuits::copy_constraint::fibonacci::FibonacciCircuit<_> =
-//             sample_circuits::copy_constraint::fibonacci::FibonacciCircuit::<Fr>(PhantomData);
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         println!("output_status: {:?}", output_status);
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_fibonacci_constant_init_test() {
-//         let circuit =
-//             sample_circuits::copy_constraint::fibonacci_constant_init::FibonacciCircuit::<Fr>(PhantomData);
-//         let k: u32 = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         println!("output_status: {:?}", output_status);
-//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_single_lookup_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::lookup_underconstrained::MyCircuit::<Fr>(PhantomData);
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-//     }
-
-//     #[test]
-//     fn analyze_underconstrained_multiple_uninterpreted_lookup_random_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::Uninterpreted,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
-//     }
-
-//     #[test]
-//     fn analyze_underconstrained_multiple_interpreted_lookup_random_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::Interpreted,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_multiple_matched_lookups_inline_random_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
-
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_multiple_matched_lookups_interpreted_random_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
-
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::Interpreted,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_multiple_lookup_random_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Random,
-//             verification_input: VerificationInput {
-//                 instances_string: analyzer.instace_cells.clone(),
-//                 iterations: 5,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_uninterpreted_specific_lookup_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&3));
-//         let mut specified_instance_cols = HashMap::new();
-//         specified_instance_cols.insert("I-0-2".to_owned(), 6);
-//         specified_instance_cols.insert("I-0-1".to_owned(), 1);
-//         specified_instance_cols.insert("I-0-0".to_owned(), 1);
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Specific,
-//             verification_input: VerificationInput {
-//                 instances_string: specified_instance_cols,
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::Uninterpreted,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_interpreted_specific_lookup_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&3));
-//         let mut specified_instance_cols = HashMap::new();
-//         specified_instance_cols.insert("I-0-2".to_owned(), 6);
-//         specified_instance_cols.insert("I-0-1".to_owned(), 1);
-//         specified_instance_cols.insert("I-0-0".to_owned(), 1);
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Specific,
-//             verification_input: VerificationInput {
-//                 instances_string: specified_instance_cols,
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::Interpreted,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-//     #[test]
-//     fn analyze_underconstrained_lookup_test() {
-//         let circuit =
-//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-//         let k = 11;
-
-//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-//         assert!(analyzer.instace_cells.len().eq(&3));
-//         let mut specified_instance_cols = HashMap::new();
-//         specified_instance_cols.insert("I-0-2".to_owned(), 6);
-//         specified_instance_cols.insert("I-0-1".to_owned(), 1);
-//         specified_instance_cols.insert("I-0-0".to_owned(), 1);
-
-//         let modulus = bn256::fr::MODULUS_STR;
-//         let without_prefix = modulus.trim_start_matches("0x");
-//         let prime = BigInt::from_str_radix(without_prefix, 16)
-//             .unwrap()
-//             .to_string();
-
-//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-//             verification_method: VerificationMethod::Specific,
-//             verification_input: VerificationInput {
-//                 instances_string: specified_instance_cols,
-//                 iterations: 1,
-//             },
-//             lookup_method: LookupMethod::InlineConstraints,
-//         };
-//         let output_status = analyzer
-//             .analyze_underconstrained(analyzer_input, &prime)
-//             .unwrap()
-//             .output_status;
-//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-//     }
-// }
+#[cfg(test)]
+#[cfg(feature = "use_zcash_halo2_proofs")]
+mod tests {
+    use crate::circuit_analyzer::analyzer::Analyzer;
+    use crate::io::analyzer_io_type::{AnalyzerType, LookupMethod};
+    use crate::io::{
+        analyzer_io_type,
+        analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
+    };
+    use crate::sample_circuits::zcash as sample_circuits;
+    use halo2curves::bn256;
+    use zcash_halo2_proofs::pasta::Fp as Fr;
+
+    use num::{BigInt, Num};
+    use std::collections::HashMap;
+    use std::marker::PhantomData;
+    use ff::PrimeField;
+
+    #[test]
+    fn create_zcash_analyzer_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.cs.gates.len().eq(&3));
+        assert!(analyzer.cs.degree().eq(&3));
+        //assert!(analyzer.cs.num_advice_columns().eq(&3));
+        //assert!(analyzer.cs.num_instance_columns().eq(&1));
+        //assert!(analyzer.cs.num_selectors.eq(&1) || analyzer.cs.num_fixed_columns().eq(&1));
+    }
+
+    #[test]
+    fn extract_instance_cols_zcash_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let analyzer = Analyzer::new(&circuit, k).unwrap();
+        assert!(analyzer.instace_cells.len().eq(&1));
+        assert!(analyzer.instace_cells.contains_key("I-0-0"));
+        assert!(analyzer.instace_cells.iter().next().unwrap().1.eq(&0));
+    }
+
+    #[test]
+    fn set_user_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&1));
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells,
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        assert!(analyzer_input
+            .verification_method
+            .eq(&VerificationMethod::Random));
+        assert!(analyzer_input.verification_input.iterations.eq(&5));
+    }
+
+    #[test]
+    fn simple_test() {
+        let circuit =
+            sample_circuits::simple::mul::MulCircuit::<Fr>::default(
+            );
+        let k: u32 = 3;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.clone().len().eq(&2));
+
+        let modulus = Fr::MODULUS;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+
+    #[test]
+    fn not_under_constrained_enough_random_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.clone().len().eq(&1));
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
+    }
+
+    #[test]
+    fn not_under_constrained_not_enough_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.clone().len().eq(&1));
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+
+    #[test]
+    fn not_under_constrained_not_enough_input_1_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.clone().len().eq(&1));
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 4,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+
+    #[test]
+    fn not_under_constrained_exact_spec_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&1));
+        let mut specified_instance_cols = HashMap::new();
+        for var in analyzer.instace_cells.iter() {
+            specified_instance_cols.insert(var.0.clone(), 3);
+        }
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: specified_instance_cols,
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+
+    #[test]
+    fn not_under_constrained_not_exact_spec_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+            );
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&1));
+        let mut specified_instance_cols = HashMap::new();
+        for var in analyzer.instace_cells.iter() {
+            specified_instance_cols.insert(var.0.clone(), 1);
+        }
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: specified_instance_cols,
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+
+    #[test]
+    fn under_constrained_enough_random_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+                Fr,
+            >::default();
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+        assert!(analyzer.instace_cells.clone().len().eq(&1));
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
+
+    #[test]
+    fn under_constrained_not_enough_random_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+                Fr,
+            >::default();
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.clone().len().eq(&1));
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
+
+    #[test]
+    fn under_constrained_exact_spec_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+                Fr,
+            >::default();
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&1));
+        let mut specified_instance_cols = HashMap::new();
+        for var in analyzer.instace_cells.iter() {
+            specified_instance_cols.insert(var.0.clone(), 3);
+        }
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: specified_instance_cols,
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
+
+    #[test]
+    fn under_constrained_not_exact_spec_input_test() {
+        let circuit =
+            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+                Fr,
+            >::default();
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&1));
+        let mut specified_instance_cols = HashMap::new();
+        for var in analyzer.instace_cells.iter() {
+            specified_instance_cols.insert(var.0.clone(), 1);
+        }
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: specified_instance_cols,
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
+
+    #[test]
+    fn analyze_unused_columns_test() {
+        let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
+            sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
+        let k = 5;
+
+        //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+        let output_status = analyzer.analyze_unused_columns().unwrap().output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::UnusedColumns));
+        assert!(analyzer.log().len().gt(&0))
+    }
+
+    #[test]
+    fn analyze_unused_custom_gates_test() {
+        let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
+            sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
+        let k = 5;
+
+        //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+        let output_status = analyzer
+            .analyze_unused_custom_gates()
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::UnusedCustomGates));
+        assert!(analyzer.log().len().gt(&0))
+    }
+
+    #[test]
+    fn analyze_unconstrained_cells() {
+        let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
+            sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
+        let k = 5;
+
+        //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+        let output_status = analyzer
+            .analyze_unconstrained_cells()
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::UnconstrainedCells));
+        assert!(analyzer.log().len().gt(&0))
+    }
+
+    #[test]
+    fn analyze_underconstrained_fibonacci_test() {
+        let circuit: sample_circuits::copy_constraint::fibonacci::FibonacciCircuit<_> =
+            sample_circuits::copy_constraint::fibonacci::FibonacciCircuit::<Fr>(PhantomData);
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        println!("output_status: {:?}", output_status);
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+    #[test]
+    fn analyze_underconstrained_fibonacci_constant_init_test() {
+        let circuit =
+            sample_circuits::copy_constraint::fibonacci_constant_init::FibonacciCircuit::<Fr>(PhantomData);
+        let k: u32 = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        println!("output_status: {:?}", output_status);
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
+    #[test]
+    fn analyze_underconstrained_single_lookup_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::lookup_underconstrained::MyCircuit::<Fr>(PhantomData);
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
+
+    #[test]
+    fn analyze_underconstrained_multiple_uninterpreted_lookup_random_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::Uninterpreted,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
+    }
+
+    #[test]
+    fn analyze_underconstrained_multiple_interpreted_lookup_random_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::Interpreted,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+    #[test]
+    fn analyze_underconstrained_multiple_matched_lookups_inline_random_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
+
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+    #[test]
+    fn analyze_underconstrained_multiple_matched_lookups_interpreted_random_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
+
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::Interpreted,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+    #[test]
+    fn analyze_underconstrained_multiple_lookup_random_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+    #[test]
+    fn analyze_underconstrained_uninterpreted_specific_lookup_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&3));
+        let mut specified_instance_cols = HashMap::new();
+        specified_instance_cols.insert("I-0-2".to_owned(), 6);
+        specified_instance_cols.insert("I-0-1".to_owned(), 1);
+        specified_instance_cols.insert("I-0-0".to_owned(), 1);
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: specified_instance_cols,
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::Uninterpreted,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
+    }
+    #[test]
+    fn analyze_underconstrained_interpreted_specific_lookup_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&3));
+        let mut specified_instance_cols = HashMap::new();
+        specified_instance_cols.insert("I-0-2".to_owned(), 6);
+        specified_instance_cols.insert("I-0-1".to_owned(), 1);
+        specified_instance_cols.insert("I-0-0".to_owned(), 1);
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: specified_instance_cols,
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::Interpreted,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+    #[test]
+    fn analyze_underconstrained_lookup_test() {
+        let circuit =
+            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+        let k = 11;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.len().eq(&3));
+        let mut specified_instance_cols = HashMap::new();
+        specified_instance_cols.insert("I-0-2".to_owned(), 6);
+        specified_instance_cols.insert("I-0-1".to_owned(), 1);
+        specified_instance_cols.insert("I-0-0".to_owned(), 1);
+
+        let modulus = bn256::fr::MODULUS_STR;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            verification_method: VerificationMethod::Specific,
+            verification_input: VerificationInput {
+                instances_string: specified_instance_cols,
+                iterations: 1,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+}

--- a/korrekt/src/test/integration_tests_zcash.rs
+++ b/korrekt/src/test/integration_tests_zcash.rs
@@ -1,798 +1,798 @@
-#[cfg(test)]
-#[cfg(feature = "use_zcash_halo2_proofs")]
-mod tests {
-    use crate::circuit_analyzer::analyzer::Analyzer;
-    use crate::io::analyzer_io_type::LookupMethod;
-    use crate::io::{
-        analyzer_io_type,
-        analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
-    };
-    use crate::sample_circuits::zcash as sample_circuits;
-    use halo2curves::bn256;
-    use zcash_halo2_proofs::pasta::Fp as Fr;
-
-    use num::{BigInt, Num};
-    use std::collections::HashMap;
-    use std::marker::PhantomData;
-    use ff::PrimeField;
-
-    #[test]
-    fn create_zcash_analyzer_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.cs.gates.len().eq(&3));
-        assert!(analyzer.cs.degree().eq(&3));
-        //assert!(analyzer.cs.num_advice_columns().eq(&3));
-        //assert!(analyzer.cs.num_instance_columns().eq(&1));
-        //assert!(analyzer.cs.num_selectors.eq(&1) || analyzer.cs.num_fixed_columns().eq(&1));
-    }
-
-    #[test]
-    fn extract_instance_cols_zcash_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let analyzer = Analyzer::new(&circuit, k).unwrap();
-        assert!(analyzer.instace_cells.len().eq(&1));
-        assert!(analyzer.instace_cells.contains_key("I-0-0"));
-        assert!(analyzer.instace_cells.iter().next().unwrap().1.eq(&0));
-    }
-
-    #[test]
-    fn set_user_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&1));
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells,
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-        assert!(analyzer_input
-            .verification_method
-            .eq(&VerificationMethod::Random));
-        assert!(analyzer_input.verification_input.iterations.eq(&5));
-    }
-
-    #[test]
-    fn simple_test() {
-        let circuit =
-            sample_circuits::simple::mul::MulCircuit::<Fr>::default(
-            );
-        let k: u32 = 3;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.clone().len().eq(&2));
-
-        let modulus = Fr::MODULUS;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-
-    #[test]
-    fn not_under_constrained_enough_random_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.clone().len().eq(&1));
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
-    }
-
-    #[test]
-    fn not_under_constrained_not_enough_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.clone().len().eq(&1));
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-
-    #[test]
-    fn not_under_constrained_not_enough_input_1_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.clone().len().eq(&1));
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 4,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-
-    #[test]
-    fn not_under_constrained_exact_spec_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&1));
-        let mut specified_instance_cols = HashMap::new();
-        for var in analyzer.instace_cells.iter() {
-            specified_instance_cols.insert(var.0.clone(), 3);
-        }
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: specified_instance_cols,
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-
-    #[test]
-    fn not_under_constrained_not_exact_spec_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
-            );
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&1));
-        let mut specified_instance_cols = HashMap::new();
-        for var in analyzer.instace_cells.iter() {
-            specified_instance_cols.insert(var.0.clone(), 1);
-        }
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: specified_instance_cols,
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-
-    #[test]
-    fn under_constrained_enough_random_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-                Fr,
-            >::default();
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-        assert!(analyzer.instace_cells.clone().len().eq(&1));
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-    }
-
-    #[test]
-    fn under_constrained_not_enough_random_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-                Fr,
-            >::default();
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.clone().len().eq(&1));
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-    }
-
-    #[test]
-    fn under_constrained_exact_spec_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-                Fr,
-            >::default();
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&1));
-        let mut specified_instance_cols = HashMap::new();
-        for var in analyzer.instace_cells.iter() {
-            specified_instance_cols.insert(var.0.clone(), 3);
-        }
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: specified_instance_cols,
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-    }
-
-    #[test]
-    fn under_constrained_not_exact_spec_input_test() {
-        let circuit =
-            sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
-                Fr,
-            >::default();
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&1));
-        let mut specified_instance_cols = HashMap::new();
-        for var in analyzer.instace_cells.iter() {
-            specified_instance_cols.insert(var.0.clone(), 1);
-        }
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: specified_instance_cols,
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-    }
-
-    #[test]
-    fn analyze_unused_columns_test() {
-        let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
-            sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
-        let k = 5;
-
-        //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-        let output_status = analyzer.analyze_unused_columns().unwrap().output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::UnusedColumns));
-        assert!(analyzer.log().len().gt(&0))
-    }
-
-    #[test]
-    fn analyze_unused_custom_gates_test() {
-        let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
-            sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
-        let k = 5;
-
-        //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-        let output_status = analyzer
-            .analyze_unused_custom_gates()
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::UnusedCustomGates));
-        assert!(analyzer.log().len().gt(&0))
-    }
-
-    #[test]
-    fn analyze_unconstrained_cells() {
-        let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
-            sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
-        let k = 5;
-
-        //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-        let output_status = analyzer
-            .analyze_unconstrained_cells()
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::UnconstrainedCells));
-        assert!(analyzer.log().len().gt(&0))
-    }
-
-    #[test]
-    fn analyze_underconstrained_fibonacci_test() {
-        let circuit: sample_circuits::copy_constraint::fibonacci::FibonacciCircuit<_> =
-            sample_circuits::copy_constraint::fibonacci::FibonacciCircuit::<Fr>(PhantomData);
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        println!("output_status: {:?}", output_status);
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-    #[test]
-    fn analyze_underconstrained_fibonacci_constant_init_test() {
-        let circuit =
-            sample_circuits::copy_constraint::fibonacci_constant_init::FibonacciCircuit::<Fr>(PhantomData);
-        let k: u32 = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        println!("output_status: {:?}", output_status);
-        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-    }
-    #[test]
-    fn analyze_underconstrained_single_lookup_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::lookup_underconstrained::MyCircuit::<Fr>(PhantomData);
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
-    }
-
-    #[test]
-    fn analyze_underconstrained_multiple_uninterpreted_lookup_random_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::Uninterpreted,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
-    }
-
-    #[test]
-    fn analyze_underconstrained_multiple_interpreted_lookup_random_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::Interpreted,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-    #[test]
-    fn analyze_underconstrained_multiple_matched_lookups_inline_random_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
-
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-    #[test]
-    fn analyze_underconstrained_multiple_matched_lookups_interpreted_random_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
-
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::Interpreted,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-    #[test]
-    fn analyze_underconstrained_multiple_lookup_random_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Random,
-            verification_input: VerificationInput {
-                instances_string: analyzer.instace_cells.clone(),
-                iterations: 5,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-    #[test]
-    fn analyze_underconstrained_uninterpreted_specific_lookup_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&3));
-        let mut specified_instance_cols = HashMap::new();
-        specified_instance_cols.insert("I-0-2".to_owned(), 6);
-        specified_instance_cols.insert("I-0-1".to_owned(), 1);
-        specified_instance_cols.insert("I-0-0".to_owned(), 1);
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: specified_instance_cols,
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::Uninterpreted,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
-    }
-    #[test]
-    fn analyze_underconstrained_interpreted_specific_lookup_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&3));
-        let mut specified_instance_cols = HashMap::new();
-        specified_instance_cols.insert("I-0-2".to_owned(), 6);
-        specified_instance_cols.insert("I-0-1".to_owned(), 1);
-        specified_instance_cols.insert("I-0-0".to_owned(), 1);
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: specified_instance_cols,
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::Interpreted,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-    #[test]
-    fn analyze_underconstrained_lookup_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
-        let k = 11;
-
-        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
-
-        assert!(analyzer.instace_cells.len().eq(&3));
-        let mut specified_instance_cols = HashMap::new();
-        specified_instance_cols.insert("I-0-2".to_owned(), 6);
-        specified_instance_cols.insert("I-0-1".to_owned(), 1);
-        specified_instance_cols.insert("I-0-0".to_owned(), 1);
-
-        let modulus = bn256::fr::MODULUS_STR;
-        let without_prefix = modulus.trim_start_matches("0x");
-        let prime = BigInt::from_str_radix(without_prefix, 16)
-            .unwrap()
-            .to_string();
-
-        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-            verification_method: VerificationMethod::Specific,
-            verification_input: VerificationInput {
-                instances_string: specified_instance_cols,
-                iterations: 1,
-            },
-            lookup_method: LookupMethod::InlineConstraints,
-        };
-        let output_status = analyzer
-            .analyze_underconstrained(analyzer_input, &prime)
-            .unwrap()
-            .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
-    }
-}
+// #[cfg(test)]
+// #[cfg(feature = "use_zcash_halo2_proofs")]
+// mod tests {
+//     use crate::circuit_analyzer::analyzer::Analyzer;
+//     use crate::io::analyzer_io_type::LookupMethod;
+//     use crate::io::{
+//         analyzer_io_type,
+//         analyzer_io_type::{AnalyzerOutputStatus, VerificationInput, VerificationMethod},
+//     };
+//     use crate::sample_circuits::zcash as sample_circuits;
+//     use halo2curves::bn256;
+//     use zcash_halo2_proofs::pasta::Fp as Fr;
+
+//     use num::{BigInt, Num};
+//     use std::collections::HashMap;
+//     use std::marker::PhantomData;
+//     use ff::PrimeField;
+
+//     #[test]
+//     fn create_zcash_analyzer_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.cs.gates.len().eq(&3));
+//         assert!(analyzer.cs.degree().eq(&3));
+//         //assert!(analyzer.cs.num_advice_columns().eq(&3));
+//         //assert!(analyzer.cs.num_instance_columns().eq(&1));
+//         //assert!(analyzer.cs.num_selectors.eq(&1) || analyzer.cs.num_fixed_columns().eq(&1));
+//     }
+
+//     #[test]
+//     fn extract_instance_cols_zcash_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let analyzer = Analyzer::new(&circuit, k).unwrap();
+//         assert!(analyzer.instace_cells.len().eq(&1));
+//         assert!(analyzer.instace_cells.contains_key("I-0-0"));
+//         assert!(analyzer.instace_cells.iter().next().unwrap().1.eq(&0));
+//     }
+
+//     #[test]
+//     fn set_user_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&1));
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells,
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+//         assert!(analyzer_input
+//             .verification_method
+//             .eq(&VerificationMethod::Random));
+//         assert!(analyzer_input.verification_input.iterations.eq(&5));
+//     }
+
+//     #[test]
+//     fn simple_test() {
+//         let circuit =
+//             sample_circuits::simple::mul::MulCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 3;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.clone().len().eq(&2));
+
+//         let modulus = Fr::MODULUS;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+
+//     #[test]
+//     fn not_under_constrained_enough_random_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.clone().len().eq(&1));
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrained));
+//     }
+
+//     #[test]
+//     fn not_under_constrained_not_enough_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.clone().len().eq(&1));
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+
+//     #[test]
+//     fn not_under_constrained_not_enough_input_1_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.clone().len().eq(&1));
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 4,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+
+//     #[test]
+//     fn not_under_constrained_exact_spec_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&1));
+//         let mut specified_instance_cols = HashMap::new();
+//         for var in analyzer.instace_cells.iter() {
+//             specified_instance_cols.insert(var.0.clone(), 3);
+//         }
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Specific,
+//             verification_input: VerificationInput {
+//                 instances_string: specified_instance_cols,
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+
+//     #[test]
+//     fn not_under_constrained_not_exact_spec_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(
+//             );
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&1));
+//         let mut specified_instance_cols = HashMap::new();
+//         for var in analyzer.instace_cells.iter() {
+//             specified_instance_cols.insert(var.0.clone(), 1);
+//         }
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Specific,
+//             verification_input: VerificationInput {
+//                 instances_string: specified_instance_cols,
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+
+//     #[test]
+//     fn under_constrained_enough_random_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+//                 Fr,
+//             >::default();
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+//         assert!(analyzer.instace_cells.clone().len().eq(&1));
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+//     }
+
+//     #[test]
+//     fn under_constrained_not_enough_random_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+//                 Fr,
+//             >::default();
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.clone().len().eq(&1));
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+//     }
+
+//     #[test]
+//     fn under_constrained_exact_spec_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+//                 Fr,
+//             >::default();
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&1));
+//         let mut specified_instance_cols = HashMap::new();
+//         for var in analyzer.instace_cells.iter() {
+//             specified_instance_cols.insert(var.0.clone(), 3);
+//         }
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Specific,
+//             verification_input: VerificationInput {
+//                 instances_string: specified_instance_cols,
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+//     }
+
+//     #[test]
+//     fn under_constrained_not_exact_spec_input_test() {
+//         let circuit =
+//             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuitUnderConstrained::<
+//                 Fr,
+//             >::default();
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&1));
+//         let mut specified_instance_cols = HashMap::new();
+//         for var in analyzer.instace_cells.iter() {
+//             specified_instance_cols.insert(var.0.clone(), 1);
+//         }
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Specific,
+//             verification_input: VerificationInput {
+//                 instances_string: specified_instance_cols,
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+//     }
+
+//     #[test]
+//     fn analyze_unused_columns_test() {
+//         let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
+//             sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
+//         let k = 5;
+
+//         //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+//         let output_status = analyzer.analyze_unused_columns().unwrap().output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::UnusedColumns));
+//         assert!(analyzer.log().len().gt(&0))
+//     }
+
+//     #[test]
+//     fn analyze_unused_custom_gates_test() {
+//         let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
+//             sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
+//         let k = 5;
+
+//         //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+//         let output_status = analyzer
+//             .analyze_unused_custom_gates()
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::UnusedCustomGates));
+//         assert!(analyzer.log().len().gt(&0))
+//     }
+
+//     #[test]
+//     fn analyze_unconstrained_cells() {
+//         let circuit: sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit<Fr> =
+//             sample_circuits::bit_decomposition::add_multiplication::AddMultCircuit::default();
+//         let k = 5;
+
+//         //let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+//         let output_status = analyzer
+//             .analyze_unconstrained_cells()
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::UnconstrainedCells));
+//         assert!(analyzer.log().len().gt(&0))
+//     }
+
+//     #[test]
+//     fn analyze_underconstrained_fibonacci_test() {
+//         let circuit: sample_circuits::copy_constraint::fibonacci::FibonacciCircuit<_> =
+//             sample_circuits::copy_constraint::fibonacci::FibonacciCircuit::<Fr>(PhantomData);
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         println!("output_status: {:?}", output_status);
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_fibonacci_constant_init_test() {
+//         let circuit =
+//             sample_circuits::copy_constraint::fibonacci_constant_init::FibonacciCircuit::<Fr>(PhantomData);
+//         let k: u32 = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         println!("output_status: {:?}", output_status);
+//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_single_lookup_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::lookup_underconstrained::MyCircuit::<Fr>(PhantomData);
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+//     }
+
+//     #[test]
+//     fn analyze_underconstrained_multiple_uninterpreted_lookup_random_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::Uninterpreted,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
+//     }
+
+//     #[test]
+//     fn analyze_underconstrained_multiple_interpreted_lookup_random_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::Interpreted,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_multiple_matched_lookups_inline_random_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
+
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_multiple_matched_lookups_interpreted_random_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
+
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::Interpreted,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_multiple_lookup_random_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Random,
+//             verification_input: VerificationInput {
+//                 instances_string: analyzer.instace_cells.clone(),
+//                 iterations: 5,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_uninterpreted_specific_lookup_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&3));
+//         let mut specified_instance_cols = HashMap::new();
+//         specified_instance_cols.insert("I-0-2".to_owned(), 6);
+//         specified_instance_cols.insert("I-0-1".to_owned(), 1);
+//         specified_instance_cols.insert("I-0-0".to_owned(), 1);
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Specific,
+//             verification_input: VerificationInput {
+//                 instances_string: specified_instance_cols,
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::Uninterpreted,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_interpreted_specific_lookup_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&3));
+//         let mut specified_instance_cols = HashMap::new();
+//         specified_instance_cols.insert("I-0-2".to_owned(), 6);
+//         specified_instance_cols.insert("I-0-1".to_owned(), 1);
+//         specified_instance_cols.insert("I-0-0".to_owned(), 1);
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Specific,
+//             verification_input: VerificationInput {
+//                 instances_string: specified_instance_cols,
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::Interpreted,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+//     #[test]
+//     fn analyze_underconstrained_lookup_test() {
+//         let circuit =
+//             sample_circuits::lookup_circuits::multiple_lookups::MyCircuit::<Fr>(PhantomData);
+//         let k = 11;
+
+//         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+//         assert!(analyzer.instace_cells.len().eq(&3));
+//         let mut specified_instance_cols = HashMap::new();
+//         specified_instance_cols.insert("I-0-2".to_owned(), 6);
+//         specified_instance_cols.insert("I-0-1".to_owned(), 1);
+//         specified_instance_cols.insert("I-0-0".to_owned(), 1);
+
+//         let modulus = bn256::fr::MODULUS_STR;
+//         let without_prefix = modulus.trim_start_matches("0x");
+//         let prime = BigInt::from_str_radix(without_prefix, 16)
+//             .unwrap()
+//             .to_string();
+
+//         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+//             verification_method: VerificationMethod::Specific,
+//             verification_input: VerificationInput {
+//                 instances_string: specified_instance_cols,
+//                 iterations: 1,
+//             },
+//             lookup_method: LookupMethod::InlineConstraints,
+//         };
+//         let output_status = analyzer
+//             .analyze_underconstrained(analyzer_input, &prime)
+//             .unwrap()
+//             .output_status;
+//         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+//     }
+// }

--- a/korrekt/src/test/integration_tests_zcash.rs
+++ b/korrekt/src/test/integration_tests_zcash.rs
@@ -11,10 +11,10 @@ mod tests {
     use halo2curves::bn256;
     use zcash_halo2_proofs::pasta::Fp as Fr;
 
+    use ff::PrimeField;
     use num::{BigInt, Num};
     use std::collections::HashMap;
     use std::marker::PhantomData;
-    use ff::PrimeField;
 
     #[test]
     fn create_zcash_analyzer_test() {
@@ -72,9 +72,7 @@ mod tests {
 
     #[test]
     fn simple_test() {
-        let circuit =
-            sample_circuits::simple::mul::MulCircuit::<Fr>::default(
-            );
+        let circuit = sample_circuits::simple::mul::MulCircuit::<Fr>::default();
         let k: u32 = 3;
 
         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
@@ -502,8 +500,9 @@ mod tests {
     }
     #[test]
     fn analyze_underconstrained_fibonacci_constant_init_test() {
-        let circuit =
-            sample_circuits::copy_constraint::fibonacci_constant_init::FibonacciCircuit::<Fr>(PhantomData);
+        let circuit = sample_circuits::copy_constraint::fibonacci_constant_init::FibonacciCircuit::<
+            Fr,
+        >(PhantomData);
         let k: u32 = 11;
 
         let mut analyzer = Analyzer::new(&circuit, k).unwrap();
@@ -515,7 +514,7 @@ mod tests {
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -546,7 +545,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -577,7 +576,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -589,7 +588,9 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
+        assert!(
+            output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups)
+        );
     }
 
     #[test]
@@ -608,7 +609,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -624,8 +625,9 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
     }
     #[test]
     fn analyze_underconstrained_multiple_matched_lookups_inline_random_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
+        let circuit = sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(
+            PhantomData,
+        );
 
         let k = 11;
 
@@ -638,7 +640,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -654,8 +656,9 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
     }
     #[test]
     fn analyze_underconstrained_multiple_matched_lookups_interpreted_random_test() {
-        let circuit =
-            sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(PhantomData);
+        let circuit = sample_circuits::lookup_circuits::multiple_matched_lookups::MyCircuit::<Fr>(
+            PhantomData,
+        );
 
         let k = 11;
 
@@ -668,7 +671,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -698,7 +701,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Random,
             verification_input: VerificationInput {
                 instances_string: analyzer.instace_cells.clone(),
@@ -733,7 +736,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -745,7 +748,9 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .analyze_underconstrained(&analyzer_input, &prime)
             .unwrap()
             .output_status;
-        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups));
+        assert!(
+            output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocalUninterpretedLookups)
+        );
     }
     #[test]
     fn analyze_underconstrained_interpreted_specific_lookup_test() {
@@ -768,7 +773,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,
@@ -803,7 +808,7 @@ analysis_type: AnalyzerType::UnderconstrainedCircuit,
             .to_string();
 
         let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
-analysis_type: AnalyzerType::UnderconstrainedCircuit,
+            analysis_type: AnalyzerType::UnderconstrainedCircuit,
             verification_method: VerificationMethod::Specific,
             verification_input: VerificationInput {
                 instances_string: specified_instance_cols,


### PR DESCRIPTION
This PR introduces command-line interface (CLI) options, enabling users to specify profiles, analysis types, lookup methods, verification methods, and iteration counts. The README has been updated to include instructions on utilizing these options. Tests also have been updated based on the changes.