### PR TITLE
fix: allow empty selector

### DIFF
--- a/korrekt/src/circuit_analyzer/analyzer.rs
+++ b/korrekt/src/circuit_analyzer/analyzer.rs
@@ -1061,7 +1061,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
         // Extract all gates
         if !self.regions.is_empty() {
             for region in &self.regions {
-                if !region.enabled_selectors.is_empty() {
+                if self.selectors.is_empty() || !region.enabled_selectors.is_empty() {
                     let (region_begin, region_end) = region.rows.unwrap();
                     for row_num in 0..region_end - region_begin + 1 {
                         for gate in self.cs.gates.iter() {
@@ -1112,7 +1112,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
     // Extracts the lookup constraints and writes assertions using an SMT printer.
     fn decompose_lookups(&mut self, printer: &mut smt::Printer<File>) -> Result<(), anyhow::Error> {
         for region in &self.regions {
-            if !region.enabled_selectors.is_empty() {
+            if self.selectors.is_empty() || !region.enabled_selectors.is_empty() {
                 let (region_begin, region_end) = region.rows.unwrap();
                 for row_num in 0..region_end - region_begin + 1 {
                     for lookup in self.cs.lookups.iter() {
@@ -1295,7 +1295,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
         self.extract_lookups(printer, None)?;
         let mut lookup_func_map = HashMap::new();
         for region in &self.regions {
-            if !region.enabled_selectors.is_empty() {
+            if self.selectors.is_empty() || !region.enabled_selectors.is_empty() {
                 let (region_begin, region_end) = region.rows.unwrap();
                 for row_num in 0..region_end - region_begin + 1 {
                     let mut lookup_index = 0;
@@ -1469,7 +1469,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
     #[cfg(any(feature = "use_scroll_halo2_proofs"))]
     fn decompose_lookups(&self, printer: &mut smt::Printer<File>) -> Result<(), anyhow::Error> {
         for region in &self.regions {
-            if !region.enabled_selectors.is_empty() {
+            if self.selectors.is_empty() || !region.enabled_selectors.is_empty() {
                 let (region_begin, region_end) = region.rows.unwrap();
                 for row_num in 0..region_end - region_begin + 1 {
                     for lookup in &self.cs.lookups_map {

--- a/korrekt/src/sample_circuits/zcash/simple/mod.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/mod.rs
@@ -1,1 +1,2 @@
 pub mod mul;
+pub mod no_selector;

--- a/korrekt/src/sample_circuits/zcash/simple/no_selector.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/no_selector.rs
@@ -1,0 +1,147 @@
+use group::ff::Field;
+use std::marker::PhantomData;
+use zcash_halo2_proofs::circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value};
+use zcash_halo2_proofs::plonk::{
+    Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance,
+};
+use zcash_halo2_proofs::poly::Rotation;
+
+#[derive(Debug, Clone)]
+pub struct MulConfig {
+    pub col_fixed: Column<Fixed>,
+    pub col_a: Column<Advice>,
+    pub col_b: Column<Advice>,
+    pub col_c: Column<Advice>,
+    pub instance: Column<Instance>,
+}
+
+#[derive(Debug, Clone)]
+struct MulChip<F: Field> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> MulChip<F> {
+    pub fn construct(config: MulConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn configure(meta: &mut ConstraintSystem<F>) -> MulConfig {
+        let col_fixed = meta.fixed_column();
+        let col_a = meta.advice_column();
+        let col_b = meta.advice_column();
+        let col_c = meta.advice_column();
+        let instance = meta.instance_column();
+
+        meta.enable_constant(col_fixed);
+        meta.enable_equality(col_a);
+        meta.enable_equality(col_b);
+        meta.enable_equality(col_c);
+        meta.enable_equality(instance);
+
+        // computes c = -a^2
+        meta.create_gate("mul", |meta| {
+            //
+            // col_fixed | col_a | col_b | col_c
+            //      f       a      b        c
+            //
+            let f = meta.query_fixed(col_fixed);
+            let a = meta.query_advice(col_a, Rotation::cur());
+            let b = meta.query_advice(col_b, Rotation::cur());
+            let c = meta.query_advice(col_c, Rotation::cur());
+
+            vec![(f * a.clone() - b.clone()), (a * b - c)]
+        });
+
+        MulConfig {
+            col_fixed,
+            col_a,
+            col_b,
+            col_c,
+            instance,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn assign_first_row(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "first row",
+            |mut region| {
+                let fixed_cell = region.assign_fixed(
+                    || "-1",
+                    self.config.col_fixed,
+                    0,
+                    || -> Value<F> { Value::known(-F::ONE) },
+                )?;
+
+                let a_cell = region.assign_advice_from_instance(
+                    || "a",
+                    self.config.instance,
+                    0,
+                    self.config.col_a,
+                    0,
+                )?;
+
+                let b_cell = region.assign_advice(
+                    || "-1 * a",
+                    self.config.col_b,
+                    0,
+                    || a_cell.value().copied() * fixed_cell.value(),
+                )?;
+
+                let c_cell = region.assign_advice(
+                    || "a * b",
+                    self.config.col_c,
+                    0,
+                    || a_cell.value().copied() * b_cell.value(),
+                )?;
+
+                Ok(c_cell)
+            },
+        )
+    }
+
+    pub fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        cell: &AssignedCell<F, F>,
+        row: usize,
+    ) -> Result<(), Error> {
+        layouter.constrain_instance(cell.cell(), self.config.instance, row)
+    }
+}
+
+#[derive(Default)]
+pub struct MulCircuit<F>(pub PhantomData<F>);
+
+impl<F: Field> Circuit<F> for MulCircuit<F> {
+    type Config = MulConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MulChip::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let chip = MulChip::construct(config);
+
+        let prev_c = chip.assign_first_row(layouter.namespace(|| "first row"))?;
+
+        chip.expose_public(layouter.namespace(|| "out"), &prev_c, 1)?;
+        Ok(())
+    }
+}

--- a/korrekt/src/test/integration_tests_zcash.rs
+++ b/korrekt/src/test/integration_tests_zcash.rs
@@ -102,6 +102,38 @@ mod tests {
     }
 
     #[test]
+    fn no_selector_test() {
+        let circuit =
+            sample_circuits::simple::no_selector::MulCircuit::<Fr>::default(
+            );
+        let k: u32 = 3;
+
+        let mut analyzer = Analyzer::new(&circuit, k).unwrap();
+
+        assert!(analyzer.instace_cells.clone().len().eq(&2));
+
+        let modulus = Fr::MODULUS;
+        let without_prefix = modulus.trim_start_matches("0x");
+        let prime = BigInt::from_str_radix(without_prefix, 16)
+            .unwrap()
+            .to_string();
+
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instances_string: analyzer.instace_cells.clone(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+        let output_status = analyzer
+            .analyze_underconstrained(analyzer_input, &prime)
+            .unwrap()
+            .output_status;
+        assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
+    }
+
+    #[test]
     fn not_under_constrained_enough_random_input_test() {
         let circuit =
             sample_circuits::bit_decomposition::two_bit_decomp::TwoBitDecompCircuit::<Fr>::default(


### PR DESCRIPTION
While unconventional, there may be no selector at all. In that case, the constraints will always be on (and can't be turned off). See the added test `no_selector` for an example.
However, halo2-analyzer instead skips the constraints completely, causing a failure. This commit fixes the issue.

Note that this commit only includes the fix for the under-constrained circuit analysis. Other types of analysis may still be incorrect, and require further fixes.

The bug is originally discovered by @shankarapailoor.