### PR TITLE
ZKR-4188-Fixed-Permutations-SMT-Solver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ pse_halo2_proofs = { git = "https://github.com/Analyzable-Halo2/pse-halo2.git", 
 axiom_halo2_proofs = { git = "https://github.com/Analyzable-Halo2/axiom-halo2.git", package = "halo2-axiom"}
 
 [patch."https://github.com/scroll-tech/halo2.git"]
-axiom_halo2_proofs = { git = "https://github.com/Analyzable-Halo2/scroll-halo2.git", package = "halo2_proofs"}
+scroll_halo2_proofs = { git = "https://github.com/Analyzable-Halo2/scroll-halo2.git", package = "halo2_proofs"}

--- a/korrekt/src/circuit_analyzer/abstract_expr.rs
+++ b/korrekt/src/circuit_analyzer/abstract_expr.rs
@@ -114,7 +114,6 @@ pub fn eval_abstract<F: AnalyzableField>(
             //println!("cell_to_cycle_head: {:?}", cell_to_cycle_head);
             if cell_to_cycle_head.contains_key(&term) {
                 if cycle_abs_value.contains_key(&cell_to_cycle_head[&term.clone()]) {
-                    //println!("cycle_abs_value[&cell_to_cycle_head[&term]]: {:?}", cycle_abs_value[&cell_to_cycle_head[&term]]);
                     return Ok(cycle_abs_value[&cell_to_cycle_head[&term]]);
                 }
             }

--- a/korrekt/src/circuit_analyzer/abstract_expr.rs
+++ b/korrekt/src/circuit_analyzer/abstract_expr.rs
@@ -110,8 +110,6 @@ pub fn eval_abstract<F: AnalyzableField>(
                 advice_query.column_index,
                 advice_query.rotation.0 + row_num + region_begin as i32
             );
-            //println!("term: {:?}", term);
-            //println!("cell_to_cycle_head: {:?}", cell_to_cycle_head);
             if cell_to_cycle_head.contains_key(&term) {
                 if cycle_abs_value.contains_key(&cell_to_cycle_head[&term.clone()]) {
                     return Ok(cycle_abs_value[&cell_to_cycle_head[&term]]);

--- a/korrekt/src/circuit_analyzer/analyzable.rs
+++ b/korrekt/src/circuit_analyzer/analyzable.rs
@@ -207,6 +207,7 @@ impl<F: AnalyzableField> Assignment<F> for Analyzable<F> {
 
         if let Some(region) = self.current_region.as_mut() {
             region.update_extent(column.into(), row);
+            region.cells.push((column.into(), row));
             #[cfg(any(feature = "use_pse_halo2_proofs", feature = "use_pse_v1_halo2_proofs"))]
             region
                 .cells

--- a/korrekt/src/circuit_analyzer/analyzable.rs
+++ b/korrekt/src/circuit_analyzer/analyzable.rs
@@ -207,8 +207,13 @@ impl<F: AnalyzableField> Assignment<F> for Analyzable<F> {
 
         if let Some(region) = self.current_region.as_mut() {
             region.update_extent(column.into(), row);
+            #[cfg(any(feature = "use_zcash_halo2_proofs",))]
             region.cells.push((column.into(), row));
-            #[cfg(any(feature = "use_pse_halo2_proofs", feature = "use_pse_v1_halo2_proofs"))]
+            #[cfg(any(
+                feature = "use_pse_halo2_proofs",
+                feature = "use_pse_v1_halo2_proofs",
+                feature = "use_scroll_halo2_proofs",
+            ))]
             region
                 .cells
                 .entry((column.into(), row))

--- a/korrekt/src/circuit_analyzer/analyzer.rs
+++ b/korrekt/src/circuit_analyzer/analyzer.rs
@@ -752,7 +752,7 @@ impl<'b, F: AnalyzableField> Analyzer<F> {
                 let col = fixed_query.column_index;
                 let row = (fixed_query.rotation.0 + row_num) as usize + region_begin;
 
-                if col < fixed.len() && row < fixed[0].len() {
+                if col < fixed.len() && row < fixed[col].len() {
                     let t = &fixed[col][row];
                     let term = format!("(as ff{:?} F)", t);
 

--- a/korrekt/src/sample_circuits/pse/lookup_circuits/lookup_underconstrained.rs
+++ b/korrekt/src/sample_circuits/pse/lookup_circuits/lookup_underconstrained.rs
@@ -146,6 +146,8 @@ impl<F: PrimeField> FibonacciChip<F> {
                     || a_cell.value().copied() + b_cell.value(),
                 )?;
 
+                self.config.s_add.enable(&mut region, 1)?;
+
                 // assign the rest of rows
                 for row in 2..nrows {
                     b_cell.copy_advice(|| "a", &mut region, self.config.advice[0], row)?;

--- a/korrekt/src/sample_circuits/pse/mod.rs
+++ b/korrekt/src/sample_circuits/pse/mod.rs
@@ -1,3 +1,4 @@
 pub mod bit_decomposition;
 pub mod copy_constraint;
 pub mod lookup_circuits;
+pub mod simple;

--- a/korrekt/src/sample_circuits/pse/simple/mod.rs
+++ b/korrekt/src/sample_circuits/pse/simple/mod.rs
@@ -1,0 +1,4 @@
+pub mod mul;
+pub mod no_selector;
+pub mod steps;
+pub mod steps_with_fixed;

--- a/korrekt/src/sample_circuits/pse/simple/mul.rs
+++ b/korrekt/src/sample_circuits/pse/simple/mul.rs
@@ -1,0 +1,153 @@
+use group::ff::Field;
+use pse_halo2_proofs::circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value};
+use pse_halo2_proofs::plonk::{
+    Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance, Selector,
+};
+use pse_halo2_proofs::poly::Rotation;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone)]
+pub struct MulConfig {
+    pub col_fixed: Column<Fixed>,
+    pub col_a: Column<Advice>,
+    pub col_b: Column<Advice>,
+    pub col_c: Column<Advice>,
+    pub selector: Selector,
+    pub instance: Column<Instance>,
+}
+
+#[derive(Debug, Clone)]
+struct MulChip<F: Field> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> MulChip<F> {
+    pub fn construct(config: MulConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn configure(meta: &mut ConstraintSystem<F>) -> MulConfig {
+        let col_fixed = meta.fixed_column();
+        let col_a = meta.advice_column();
+        let col_b = meta.advice_column();
+        let col_c = meta.advice_column();
+        let selector = meta.selector();
+        let instance = meta.instance_column();
+
+        meta.enable_constant(col_fixed);
+        meta.enable_equality(col_a);
+        meta.enable_equality(col_b);
+        meta.enable_equality(col_c);
+        meta.enable_equality(instance);
+
+        // computes c = -a^2
+        meta.create_gate("mul", |meta| {
+            //
+            // col_fixed | col_a | col_b | col_c | selector
+            //      f       a      b        c       s
+            //
+            let s = meta.query_selector(selector);
+            let f = meta.query_fixed(col_fixed, Rotation::cur());
+            let a = meta.query_advice(col_a, Rotation::cur());
+            let b = meta.query_advice(col_b, Rotation::cur());
+            let c = meta.query_advice(col_c, Rotation::cur());
+
+            vec![s.clone() * (f * a.clone() - b.clone()), s * (a * b - c)]
+        });
+
+        MulConfig {
+            col_fixed,
+            col_a,
+            col_b,
+            col_c,
+            selector,
+            instance,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn assign_first_row(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "first row",
+            |mut region| {
+                self.config.selector.enable(&mut region, 0)?;
+
+                let fixed_cell = region.assign_fixed(
+                    || "-1",
+                    self.config.col_fixed,
+                    0,
+                    || -> Value<F> { Value::known(-F::ONE) },
+                )?;
+
+                let a_cell = region.assign_advice_from_instance(
+                    || "a",
+                    self.config.instance,
+                    0,
+                    self.config.col_a,
+                    0,
+                )?;
+
+                let b_cell = region.assign_advice(
+                    || "-1 * a",
+                    self.config.col_b,
+                    0,
+                    || a_cell.value().copied() * fixed_cell.value(),
+                )?;
+
+                let c_cell = region.assign_advice(
+                    || "a * b",
+                    self.config.col_c,
+                    0,
+                    || a_cell.value().copied() * b_cell.value(),
+                )?;
+
+                Ok(c_cell)
+            },
+        )
+    }
+
+    pub fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        cell: &AssignedCell<F, F>,
+        row: usize,
+    ) -> Result<(), Error> {
+        layouter.constrain_instance(cell.cell(), self.config.instance, row)
+    }
+}
+
+#[derive(Default)]
+pub struct MulCircuit<F>(pub PhantomData<F>);
+
+impl<F: Field> Circuit<F> for MulCircuit<F> {
+    type Config = MulConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MulChip::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let chip = MulChip::construct(config);
+
+        let prev_c = chip.assign_first_row(layouter.namespace(|| "first row"))?;
+
+        chip.expose_public(layouter.namespace(|| "out"), &prev_c, 1)?;
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/pse/simple/no_selector.rs
+++ b/korrekt/src/sample_circuits/pse/simple/no_selector.rs
@@ -1,0 +1,145 @@
+use group::ff::Field;
+use pse_halo2_proofs::circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value};
+use pse_halo2_proofs::plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance};
+use pse_halo2_proofs::poly::Rotation;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone)]
+pub struct MulConfig {
+    pub col_fixed: Column<Fixed>,
+    pub col_a: Column<Advice>,
+    pub col_b: Column<Advice>,
+    pub col_c: Column<Advice>,
+    pub instance: Column<Instance>,
+}
+
+#[derive(Debug, Clone)]
+struct MulChip<F: Field> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> MulChip<F> {
+    pub fn construct(config: MulConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn configure(meta: &mut ConstraintSystem<F>) -> MulConfig {
+        let col_fixed = meta.fixed_column();
+        let col_a = meta.advice_column();
+        let col_b = meta.advice_column();
+        let col_c = meta.advice_column();
+        let instance = meta.instance_column();
+
+        meta.enable_constant(col_fixed);
+        meta.enable_equality(col_a);
+        meta.enable_equality(col_b);
+        meta.enable_equality(col_c);
+        meta.enable_equality(instance);
+
+        // computes c = -a^2
+        meta.create_gate("mul", |meta| {
+            //
+            // col_fixed | col_a | col_b | col_c
+            //      f       a      b        c
+            //
+            let f = meta.query_fixed(col_fixed, Rotation::cur());
+            let a = meta.query_advice(col_a, Rotation::cur());
+            let b = meta.query_advice(col_b, Rotation::cur());
+            let c = meta.query_advice(col_c, Rotation::cur());
+
+            vec![(f * a.clone() - b.clone()), (a * b - c)]
+        });
+
+        MulConfig {
+            col_fixed,
+            col_a,
+            col_b,
+            col_c,
+            instance,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn assign_first_row(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "first row",
+            |mut region| {
+                let fixed_cell = region.assign_fixed(
+                    || "-1",
+                    self.config.col_fixed,
+                    0,
+                    || -> Value<F> { Value::known(-F::ONE) },
+                )?;
+
+                let a_cell = region.assign_advice_from_instance(
+                    || "a",
+                    self.config.instance,
+                    0,
+                    self.config.col_a,
+                    0,
+                )?;
+
+                let b_cell = region.assign_advice(
+                    || "-1 * a",
+                    self.config.col_b,
+                    0,
+                    || a_cell.value().copied() * fixed_cell.value(),
+                )?;
+
+                let c_cell = region.assign_advice(
+                    || "a * b",
+                    self.config.col_c,
+                    0,
+                    || a_cell.value().copied() * b_cell.value(),
+                )?;
+
+                Ok(c_cell)
+            },
+        )
+    }
+
+    pub fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        cell: &AssignedCell<F, F>,
+        row: usize,
+    ) -> Result<(), Error> {
+        layouter.constrain_instance(cell.cell(), self.config.instance, row)
+    }
+}
+
+#[derive(Default)]
+pub struct MulCircuit<F>(pub PhantomData<F>);
+
+impl<F: Field> Circuit<F> for MulCircuit<F> {
+    type Config = MulConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MulChip::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let chip = MulChip::construct(config);
+
+        let prev_c = chip.assign_first_row(layouter.namespace(|| "first row"))?;
+
+        chip.expose_public(layouter.namespace(|| "out"), &prev_c, 1)?;
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/pse/simple/steps.rs
+++ b/korrekt/src/sample_circuits/pse/simple/steps.rs
@@ -1,7 +1,7 @@
 // ANCHOR: full
 use std::{marker::PhantomData, net::IpAddr};
 
-use zcash_halo2_proofs::{
+use pse_halo2_proofs::{
     circuit::{layouter, AssignedCell, Layouter, SimpleFloorPlanner, Value},
     dev::MockProver,
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
@@ -83,8 +83,6 @@ impl<F: PrimeField> ArithmeticChip<F> {
 
                 // force input = w0
                 region.constrain_equal(w0.cell(), input.cell())?;
-                //println!("input is: {:?}", input);
-                c0.copy_advice(|| "annotation", &mut region, self.advice, 0)?;
                 self.q_fix.enable(&mut region, 0)?;
                 Ok(())
             },
@@ -179,7 +177,7 @@ impl<F: PrimeField> ArithmeticChip<F> {
         // if q_fix = 1: c0 = w0
         meta.create_gate("fixed", |meta| {
             let w0 = meta.query_advice(advice, Rotation::cur());
-            let c0 = meta.query_fixed(fixed);
+            let c0 = meta.query_fixed(fixed, Rotation::cur());
             let q_fix = meta.query_selector(q_fix);
             vec![q_fix * (w0 - c0)]
         });
@@ -247,7 +245,6 @@ impl<F: PrimeField> Circuit<F> for TestCircuit<F> {
 
         // this will allow us to have equality constraints
         meta.enable_equality(advice);
-        meta.enable_equality(fixed);
 
         let arith = ArithmeticChip::configure(meta, advice, fixed);
 

--- a/korrekt/src/sample_circuits/pse/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/pse/simple/steps_with_fixed.rs
@@ -83,7 +83,6 @@ impl<F: PrimeField> ArithmeticChip<F> {
 
                 // force input = w0
                 region.constrain_equal(w0.cell(), input.cell())?;
-                //println!("input is: {:?}", input);
                 c0.copy_advice(|| "annotation", &mut region, self.advice, 0)?;
                 self.q_fix.enable(&mut region, 0)?;
                 Ok(())

--- a/korrekt/src/sample_circuits/pse/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/pse/simple/steps_with_fixed.rs
@@ -1,7 +1,7 @@
 // ANCHOR: full
 use std::{marker::PhantomData, net::IpAddr};
 
-use zcash_halo2_proofs::{
+use pse_halo2_proofs::{
     circuit::{layouter, AssignedCell, Layouter, SimpleFloorPlanner, Value},
     dev::MockProver,
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
@@ -179,7 +179,7 @@ impl<F: PrimeField> ArithmeticChip<F> {
         // if q_fix = 1: c0 = w0
         meta.create_gate("fixed", |meta| {
             let w0 = meta.query_advice(advice, Rotation::cur());
-            let c0 = meta.query_fixed(fixed);
+            let c0 = meta.query_fixed(fixed, Rotation::cur());
             let q_fix = meta.query_selector(q_fix);
             vec![q_fix * (w0 - c0)]
         });

--- a/korrekt/src/sample_circuits/pse_v1/lookup_circuits/lookup_underconstrained.rs
+++ b/korrekt/src/sample_circuits/pse_v1/lookup_circuits/lookup_underconstrained.rs
@@ -142,6 +142,8 @@ impl<F: FieldExt> FibonacciChip<F> {
                     || a_cell.value().copied() + b_cell.value(),
                 )?;
 
+                self.config.s_add.enable(&mut region, 1)?;
+
                 // assign the rest of rows
                 for row in 2..nrows {
                     b_cell.copy_advice(|| "a", &mut region, self.config.advice[0], row)?;

--- a/korrekt/src/sample_circuits/pse_v1/mod.rs
+++ b/korrekt/src/sample_circuits/pse_v1/mod.rs
@@ -1,3 +1,4 @@
 pub mod bit_decomposition;
 pub mod copy_constraint;
 pub mod lookup_circuits;
+pub mod simple;

--- a/korrekt/src/sample_circuits/pse_v1/simple/mod.rs
+++ b/korrekt/src/sample_circuits/pse_v1/simple/mod.rs
@@ -1,0 +1,4 @@
+pub mod mul;
+pub mod no_selector;
+pub mod steps;
+pub mod steps_with_fixed;

--- a/korrekt/src/sample_circuits/pse_v1/simple/mul.rs
+++ b/korrekt/src/sample_circuits/pse_v1/simple/mul.rs
@@ -1,0 +1,148 @@
+use crate::circuit_analyzer::halo2_proofs_libs::*;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone)]
+pub struct MulConfig {
+    pub col_fixed: Column<Fixed>,
+    pub col_a: Column<Advice>,
+    pub col_b: Column<Advice>,
+    pub col_c: Column<Advice>,
+    pub selector: Selector,
+    pub instance: Column<Instance>,
+}
+
+#[derive(Debug, Clone)]
+struct MulChip<F: FieldExt> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt> MulChip<F> {
+    pub fn construct(config: MulConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn configure(meta: &mut ConstraintSystem<F>) -> MulConfig {
+        let col_fixed = meta.fixed_column();
+        let col_a = meta.advice_column();
+        let col_b = meta.advice_column();
+        let col_c = meta.advice_column();
+        let selector = meta.selector();
+        let instance = meta.instance_column();
+
+        meta.enable_constant(col_fixed);
+        meta.enable_equality(col_a);
+        meta.enable_equality(col_b);
+        meta.enable_equality(col_c);
+        meta.enable_equality(instance);
+
+        // computes c = -a^2
+        meta.create_gate("mul", |meta| {
+            //
+            // col_fixed | col_a | col_b | col_c | selector
+            //      f       a      b        c       s
+            //
+            let s = meta.query_selector(selector);
+            let f = meta.query_fixed(col_fixed, Rotation::cur());
+            let a = meta.query_advice(col_a, Rotation::cur());
+            let b = meta.query_advice(col_b, Rotation::cur());
+            let c = meta.query_advice(col_c, Rotation::cur());
+
+            vec![s.clone() * (f * a.clone() - b.clone()), s * (a * b - c)]
+        });
+
+        MulConfig {
+            col_fixed,
+            col_a,
+            col_b,
+            col_c,
+            selector,
+            instance,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn assign_first_row(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "first row",
+            |mut region| {
+                self.config.selector.enable(&mut region, 0)?;
+
+                let fixed_cell = region.assign_fixed(
+                    || "-1",
+                    self.config.col_fixed,
+                    0,
+                    || -> Value<F> { Value::known(-F::from_u128(1)) },
+                )?;
+
+                let a_cell = region.assign_advice_from_instance(
+                    || "a",
+                    self.config.instance,
+                    0,
+                    self.config.col_a,
+                    0,
+                )?;
+
+                let b_cell = region.assign_advice(
+                    || "-1 * a",
+                    self.config.col_b,
+                    0,
+                    || a_cell.value().copied() * fixed_cell.value(),
+                )?;
+
+                let c_cell = region.assign_advice(
+                    || "a * b",
+                    self.config.col_c,
+                    0,
+                    || a_cell.value().copied() * b_cell.value(),
+                )?;
+
+                Ok(c_cell)
+            },
+        )
+    }
+
+    pub fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        cell: &AssignedCell<F, F>,
+        row: usize,
+    ) -> Result<(), Error> {
+        layouter.constrain_instance(cell.cell(), self.config.instance, row)
+    }
+}
+
+#[derive(Default)]
+pub struct MulCircuit<F>(pub PhantomData<F>);
+
+impl<F: FieldExt> Circuit<F> for MulCircuit<F> {
+    type Config = MulConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MulChip::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let chip = MulChip::construct(config);
+
+        let prev_c = chip.assign_first_row(layouter.namespace(|| "first row"))?;
+
+        chip.expose_public(layouter.namespace(|| "out"), &prev_c, 1)?;
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/pse_v1/simple/no_selector.rs
+++ b/korrekt/src/sample_circuits/pse_v1/simple/no_selector.rs
@@ -1,0 +1,144 @@
+use halo2curves::group::ff::PrimeField;
+use std::marker::PhantomData;
+
+use crate::circuit_analyzer::halo2_proofs_libs::*;
+
+#[derive(Debug, Clone)]
+pub struct MulConfig {
+    pub col_fixed: Column<Fixed>,
+    pub col_a: Column<Advice>,
+    pub col_b: Column<Advice>,
+    pub col_c: Column<Advice>,
+    pub instance: Column<Instance>,
+}
+
+#[derive(Debug, Clone)]
+struct MulChip<F: FieldExt> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt> MulChip<F> {
+    pub fn construct(config: MulConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn configure(meta: &mut ConstraintSystem<F>) -> MulConfig {
+        let col_fixed = meta.fixed_column();
+        let col_a = meta.advice_column();
+        let col_b = meta.advice_column();
+        let col_c = meta.advice_column();
+        let instance = meta.instance_column();
+
+        meta.enable_constant(col_fixed);
+        meta.enable_equality(col_a);
+        meta.enable_equality(col_b);
+        meta.enable_equality(col_c);
+        meta.enable_equality(instance);
+
+        // computes c = -a^2
+        meta.create_gate("mul", |meta| {
+            //
+            // col_fixed | col_a | col_b | col_c
+            //      f       a      b        c
+            //
+            let f = meta.query_fixed(col_fixed, Rotation::cur());
+            let a = meta.query_advice(col_a, Rotation::cur());
+            let b = meta.query_advice(col_b, Rotation::cur());
+            let c = meta.query_advice(col_c, Rotation::cur());
+
+            vec![(f * a.clone() - b.clone()), (a * b - c)]
+        });
+
+        MulConfig {
+            col_fixed,
+            col_a,
+            col_b,
+            col_c,
+            instance,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn assign_first_row(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "first row",
+            |mut region| {
+                let fixed_cell = region.assign_fixed(
+                    || "-1",
+                    self.config.col_fixed,
+                    0,
+                    || -> Value<F> { Value::known(-F::from_u128(1)) },
+                )?;
+
+                let a_cell = region.assign_advice_from_instance(
+                    || "a",
+                    self.config.instance,
+                    0,
+                    self.config.col_a,
+                    0,
+                )?;
+
+                let b_cell = region.assign_advice(
+                    || "-1 * a",
+                    self.config.col_b,
+                    0,
+                    || a_cell.value().copied() * fixed_cell.value(),
+                )?;
+
+                let c_cell = region.assign_advice(
+                    || "a * b",
+                    self.config.col_c,
+                    0,
+                    || a_cell.value().copied() * b_cell.value(),
+                )?;
+
+                Ok(c_cell)
+            },
+        )
+    }
+
+    pub fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        cell: &AssignedCell<F, F>,
+        row: usize,
+    ) -> Result<(), Error> {
+        layouter.constrain_instance(cell.cell(), self.config.instance, row)
+    }
+}
+
+#[derive(Default)]
+pub struct MulCircuit<F>(pub PhantomData<F>);
+
+impl<F: FieldExt> Circuit<F> for MulCircuit<F> {
+    type Config = MulConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MulChip::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let chip = MulChip::construct(config);
+
+        let prev_c = chip.assign_first_row(layouter.namespace(|| "first row"))?;
+
+        chip.expose_public(layouter.namespace(|| "out"), &prev_c, 1)?;
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/pse_v1/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/pse_v1/simple/steps_with_fixed.rs
@@ -76,7 +76,6 @@ impl<F: FieldExt> ArithmeticChip<F> {
 
                 // force input = w0
                 region.constrain_equal(w0.cell(), input.cell())?;
-                //println!("input is: {:?}", input);
                 c0.copy_advice(|| "annotation", &mut region, self.advice, 0)?;
                 self.q_fix.enable(&mut region, 0)?;
                 Ok(())

--- a/korrekt/src/sample_circuits/pse_v1/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/pse_v1/simple/steps_with_fixed.rs
@@ -1,23 +1,16 @@
 // ANCHOR: full
 use std::{marker::PhantomData, net::IpAddr};
 
-use zcash_halo2_proofs::{
-    circuit::{layouter, AssignedCell, Layouter, SimpleFloorPlanner, Value},
-    dev::MockProver,
-    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
-    poly::Rotation,
-};
-
-use ff::{Field, PrimeField};
+use crate::circuit_analyzer::halo2_proofs_libs::*;
 
 // ANCHOR: witness
-pub struct TestCircuit<F: Field> {
+pub struct TestCircuit<F: FieldExt> {
     _ph: PhantomData<F>,
     a: Value<F>, // secret
     b: Value<F>, // secret
 }
 
-impl<Fr: PrimeField> Default for TestCircuit<Fr> {
+impl<Fr: FieldExt> Default for TestCircuit<Fr> {
     fn default() -> Self {
         TestCircuit {
             _ph: PhantomData,
@@ -29,7 +22,7 @@ impl<Fr: PrimeField> Default for TestCircuit<Fr> {
 // ANCHOR_END: witness
 
 #[derive(Clone, Debug)]
-pub struct TestConfig<F: PrimeField> {
+pub struct TestConfig<F: FieldExt> {
     _ph: PhantomData<F>,
     advice: Column<Advice>,
     fixed: Column<Fixed>,
@@ -37,7 +30,7 @@ pub struct TestConfig<F: PrimeField> {
 }
 
 #[derive(Debug, Clone)]
-struct ArithmeticChip<F: PrimeField> {
+struct ArithmeticChip<F: FieldExt> {
     q_add: Selector,
     q_mul: Selector,
     q_fix: Selector,
@@ -46,7 +39,7 @@ struct ArithmeticChip<F: PrimeField> {
     _ph: PhantomData<F>,
 }
 
-impl<F: PrimeField> ArithmeticChip<F> {
+impl<F: FieldExt> ArithmeticChip<F> {
     // allocate a new unconstrained value
     fn free(
         &self,
@@ -179,7 +172,7 @@ impl<F: PrimeField> ArithmeticChip<F> {
         // if q_fix = 1: c0 = w0
         meta.create_gate("fixed", |meta| {
             let w0 = meta.query_advice(advice, Rotation::cur());
-            let c0 = meta.query_fixed(fixed);
+            let c0 = meta.query_fixed(fixed, Rotation::cur());
             let q_fix = meta.query_selector(q_fix);
             vec![q_fix * (w0 - c0)]
         });
@@ -229,7 +222,7 @@ impl<F: PrimeField> ArithmeticChip<F> {
     }
 }
 
-impl<F: PrimeField> Circuit<F> for TestCircuit<F> {
+impl<F: FieldExt> Circuit<F> for TestCircuit<F> {
     type Config = TestConfig<F>;
     type FloorPlanner = SimpleFloorPlanner;
 

--- a/korrekt/src/sample_circuits/scroll/mod.rs
+++ b/korrekt/src/sample_circuits/scroll/mod.rs
@@ -1,3 +1,4 @@
 pub mod bit_decomposition;
 pub mod copy_constraint;
 pub mod lookup_circuits;
+pub mod simple;

--- a/korrekt/src/sample_circuits/scroll/simple/mod.rs
+++ b/korrekt/src/sample_circuits/scroll/simple/mod.rs
@@ -1,0 +1,4 @@
+pub mod mul;
+pub mod no_selector;
+pub mod steps;
+pub mod steps_with_fixed;

--- a/korrekt/src/sample_circuits/scroll/simple/mul.rs
+++ b/korrekt/src/sample_circuits/scroll/simple/mul.rs
@@ -1,0 +1,153 @@
+use group::ff::Field;
+use scroll_halo2_proofs::circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value};
+use scroll_halo2_proofs::plonk::{
+    Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance, Selector,
+};
+use scroll_halo2_proofs::poly::Rotation;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone)]
+pub struct MulConfig {
+    pub col_fixed: Column<Fixed>,
+    pub col_a: Column<Advice>,
+    pub col_b: Column<Advice>,
+    pub col_c: Column<Advice>,
+    pub selector: Selector,
+    pub instance: Column<Instance>,
+}
+
+#[derive(Debug, Clone)]
+struct MulChip<F: Field> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> MulChip<F> {
+    pub fn construct(config: MulConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn configure(meta: &mut ConstraintSystem<F>) -> MulConfig {
+        let col_fixed = meta.fixed_column();
+        let col_a = meta.advice_column();
+        let col_b = meta.advice_column();
+        let col_c = meta.advice_column();
+        let selector = meta.selector();
+        let instance = meta.instance_column();
+
+        meta.enable_constant(col_fixed);
+        meta.enable_equality(col_a);
+        meta.enable_equality(col_b);
+        meta.enable_equality(col_c);
+        meta.enable_equality(instance);
+
+        // computes c = -a^2
+        meta.create_gate("mul", |meta| {
+            //
+            // col_fixed | col_a | col_b | col_c | selector
+            //      f       a      b        c       s
+            //
+            let s = meta.query_selector(selector);
+            let f = meta.query_fixed(col_fixed, Rotation::cur());
+            let a = meta.query_advice(col_a, Rotation::cur());
+            let b = meta.query_advice(col_b, Rotation::cur());
+            let c = meta.query_advice(col_c, Rotation::cur());
+
+            vec![s.clone() * (f * a.clone() - b.clone()), s * (a * b - c)]
+        });
+
+        MulConfig {
+            col_fixed,
+            col_a,
+            col_b,
+            col_c,
+            selector,
+            instance,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn assign_first_row(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "first row",
+            |mut region| {
+                self.config.selector.enable(&mut region, 0)?;
+
+                let fixed_cell = region.assign_fixed(
+                    || "-1",
+                    self.config.col_fixed,
+                    0,
+                    || -> Value<F> { Value::known(-F::ONE) },
+                )?;
+
+                let a_cell = region.assign_advice_from_instance(
+                    || "a",
+                    self.config.instance,
+                    0,
+                    self.config.col_a,
+                    0,
+                )?;
+
+                let b_cell = region.assign_advice(
+                    || "-1 * a",
+                    self.config.col_b,
+                    0,
+                    || a_cell.value().copied() * fixed_cell.value(),
+                )?;
+
+                let c_cell = region.assign_advice(
+                    || "a * b",
+                    self.config.col_c,
+                    0,
+                    || a_cell.value().copied() * b_cell.value(),
+                )?;
+
+                Ok(c_cell)
+            },
+        )
+    }
+
+    pub fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        cell: &AssignedCell<F, F>,
+        row: usize,
+    ) -> Result<(), Error> {
+        layouter.constrain_instance(cell.cell(), self.config.instance, row)
+    }
+}
+
+#[derive(Default)]
+pub struct MulCircuit<F>(pub PhantomData<F>);
+
+impl<F: Field> Circuit<F> for MulCircuit<F> {
+    type Config = MulConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MulChip::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let chip = MulChip::construct(config);
+
+        let prev_c = chip.assign_first_row(layouter.namespace(|| "first row"))?;
+
+        chip.expose_public(layouter.namespace(|| "out"), &prev_c, 1)?;
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/scroll/simple/no_selector.rs
+++ b/korrekt/src/sample_circuits/scroll/simple/no_selector.rs
@@ -1,0 +1,147 @@
+use group::ff::Field;
+use scroll_halo2_proofs::circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value};
+use scroll_halo2_proofs::plonk::{
+    Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance,
+};
+use scroll_halo2_proofs::poly::Rotation;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone)]
+pub struct MulConfig {
+    pub col_fixed: Column<Fixed>,
+    pub col_a: Column<Advice>,
+    pub col_b: Column<Advice>,
+    pub col_c: Column<Advice>,
+    pub instance: Column<Instance>,
+}
+
+#[derive(Debug, Clone)]
+struct MulChip<F: Field> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> MulChip<F> {
+    pub fn construct(config: MulConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn configure(meta: &mut ConstraintSystem<F>) -> MulConfig {
+        let col_fixed = meta.fixed_column();
+        let col_a = meta.advice_column();
+        let col_b = meta.advice_column();
+        let col_c = meta.advice_column();
+        let instance = meta.instance_column();
+
+        meta.enable_constant(col_fixed);
+        meta.enable_equality(col_a);
+        meta.enable_equality(col_b);
+        meta.enable_equality(col_c);
+        meta.enable_equality(instance);
+
+        // computes c = -a^2
+        meta.create_gate("mul", |meta| {
+            //
+            // col_fixed | col_a | col_b | col_c
+            //      f       a      b        c
+            //
+            let f = meta.query_fixed(col_fixed, Rotation::cur());
+            let a = meta.query_advice(col_a, Rotation::cur());
+            let b = meta.query_advice(col_b, Rotation::cur());
+            let c = meta.query_advice(col_c, Rotation::cur());
+
+            vec![(f * a.clone() - b.clone()), (a * b - c)]
+        });
+
+        MulConfig {
+            col_fixed,
+            col_a,
+            col_b,
+            col_c,
+            instance,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn assign_first_row(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "first row",
+            |mut region| {
+                let fixed_cell = region.assign_fixed(
+                    || "-1",
+                    self.config.col_fixed,
+                    0,
+                    || -> Value<F> { Value::known(-F::ONE) },
+                )?;
+
+                let a_cell = region.assign_advice_from_instance(
+                    || "a",
+                    self.config.instance,
+                    0,
+                    self.config.col_a,
+                    0,
+                )?;
+
+                let b_cell = region.assign_advice(
+                    || "-1 * a",
+                    self.config.col_b,
+                    0,
+                    || a_cell.value().copied() * fixed_cell.value(),
+                )?;
+
+                let c_cell = region.assign_advice(
+                    || "a * b",
+                    self.config.col_c,
+                    0,
+                    || a_cell.value().copied() * b_cell.value(),
+                )?;
+
+                Ok(c_cell)
+            },
+        )
+    }
+
+    pub fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        cell: &AssignedCell<F, F>,
+        row: usize,
+    ) -> Result<(), Error> {
+        layouter.constrain_instance(cell.cell(), self.config.instance, row)
+    }
+}
+
+#[derive(Default)]
+pub struct MulCircuit<F>(pub PhantomData<F>);
+
+impl<F: Field> Circuit<F> for MulCircuit<F> {
+    type Config = MulConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MulChip::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let chip = MulChip::construct(config);
+
+        let prev_c = chip.assign_first_row(layouter.namespace(|| "first row"))?;
+
+        chip.expose_public(layouter.namespace(|| "out"), &prev_c, 1)?;
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/scroll/simple/steps.rs
+++ b/korrekt/src/sample_circuits/scroll/simple/steps.rs
@@ -1,7 +1,7 @@
 // ANCHOR: full
 use std::{marker::PhantomData, net::IpAddr};
 
-use zcash_halo2_proofs::{
+use scroll_halo2_proofs::{
     circuit::{layouter, AssignedCell, Layouter, SimpleFloorPlanner, Value},
     dev::MockProver,
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
@@ -83,8 +83,6 @@ impl<F: PrimeField> ArithmeticChip<F> {
 
                 // force input = w0
                 region.constrain_equal(w0.cell(), input.cell())?;
-                //println!("input is: {:?}", input);
-                c0.copy_advice(|| "annotation", &mut region, self.advice, 0)?;
                 self.q_fix.enable(&mut region, 0)?;
                 Ok(())
             },
@@ -179,7 +177,7 @@ impl<F: PrimeField> ArithmeticChip<F> {
         // if q_fix = 1: c0 = w0
         meta.create_gate("fixed", |meta| {
             let w0 = meta.query_advice(advice, Rotation::cur());
-            let c0 = meta.query_fixed(fixed);
+            let c0 = meta.query_fixed(fixed, Rotation::cur());
             let q_fix = meta.query_selector(q_fix);
             vec![q_fix * (w0 - c0)]
         });
@@ -247,7 +245,6 @@ impl<F: PrimeField> Circuit<F> for TestCircuit<F> {
 
         // this will allow us to have equality constraints
         meta.enable_equality(advice);
-        meta.enable_equality(fixed);
 
         let arith = ArithmeticChip::configure(meta, advice, fixed);
 

--- a/korrekt/src/sample_circuits/scroll/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/scroll/simple/steps_with_fixed.rs
@@ -83,7 +83,6 @@ impl<F: PrimeField> ArithmeticChip<F> {
 
                 // force input = w0
                 region.constrain_equal(w0.cell(), input.cell())?;
-                //println!("input is: {:?}", input);
                 c0.copy_advice(|| "annotation", &mut region, self.advice, 0)?;
                 self.q_fix.enable(&mut region, 0)?;
                 Ok(())

--- a/korrekt/src/sample_circuits/scroll/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/scroll/simple/steps_with_fixed.rs
@@ -1,7 +1,7 @@
 // ANCHOR: full
 use std::{marker::PhantomData, net::IpAddr};
 
-use zcash_halo2_proofs::{
+use scroll_halo2_proofs::{
     circuit::{layouter, AssignedCell, Layouter, SimpleFloorPlanner, Value},
     dev::MockProver,
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
@@ -179,7 +179,7 @@ impl<F: PrimeField> ArithmeticChip<F> {
         // if q_fix = 1: c0 = w0
         meta.create_gate("fixed", |meta| {
             let w0 = meta.query_advice(advice, Rotation::cur());
-            let c0 = meta.query_fixed(fixed);
+            let c0 = meta.query_fixed(fixed, Rotation::cur());
             let q_fix = meta.query_selector(q_fix);
             vec![q_fix * (w0 - c0)]
         });

--- a/korrekt/src/sample_circuits/zcash/lookup_circuits/lookup_underconstrained.rs
+++ b/korrekt/src/sample_circuits/zcash/lookup_circuits/lookup_underconstrained.rs
@@ -59,17 +59,6 @@ impl<F: Field> FibonacciChip<F> {
             let c = meta.query_advice(col_c, Rotation::cur());
             vec![s * (a + b - c)]
         });
-        meta.lookup(|meta| {
-            let s = meta.query_selector(s_xor);
-            let lhs = meta.query_advice(col_a, Rotation::cur());
-            let rhs = meta.query_advice(col_b, Rotation::cur());
-            let out = meta.query_advice(col_c, Rotation::cur());
-            vec![
-                (s.clone() * lhs, xor_table[0]),
-                (s.clone() * rhs, xor_table[1]),
-                (s * out, xor_table[2]),
-            ]
-        });
 
         meta.lookup(|meta| {
             let s = meta.query_selector(s_xor);
@@ -157,6 +146,8 @@ impl<F: Field> FibonacciChip<F> {
                     0,
                     || a_cell.value().copied() + b_cell.value(),
                 )?;
+
+                self.config.s_add.enable(&mut region, 1)?;
 
                 // assign the rest of rows
                 for row in 2..nrows {

--- a/korrekt/src/sample_circuits/zcash/simple/mod.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/mod.rs
@@ -1,2 +1,4 @@
 pub mod mul;
 pub mod no_selector;
+pub mod steps;
+pub mod steps_with_fixed;

--- a/korrekt/src/sample_circuits/zcash/simple/steps.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/steps.rs
@@ -1,0 +1,272 @@
+// ANCHOR: full
+use std::{marker::PhantomData, net::IpAddr};
+
+use zcash_halo2_proofs::{
+    circuit::{layouter, AssignedCell, Layouter, SimpleFloorPlanner, Value},
+    dev::MockProver,
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
+    poly::Rotation,
+};
+
+use ff::{Field, PrimeField};
+
+// ANCHOR: witness
+pub struct TestCircuit<F: Field> {
+    _ph: PhantomData<F>,
+    a: Value<F>, // secret
+    b: Value<F>, // secret
+}
+
+impl<Fr: PrimeField> Default for TestCircuit<Fr> {
+    fn default() -> Self {
+        TestCircuit {
+            _ph: PhantomData,
+            a: Value::known(Fr::from_u128(2)),
+            b: Value::known(Fr::from_u128(4)),
+        }
+    }
+}
+// ANCHOR_END: witness
+
+#[derive(Clone, Debug)]
+pub struct TestConfig<F: PrimeField> {
+    _ph: PhantomData<F>,
+    advice: Column<Advice>,
+    fixed: Column<Fixed>,
+    arith: ArithmeticChip<F>,
+}
+
+#[derive(Debug, Clone)]
+struct ArithmeticChip<F: PrimeField> {
+    q_add: Selector,
+    q_mul: Selector,
+    q_fix: Selector,
+    advice: Column<Advice>,
+    fixed: Column<Fixed>,
+    _ph: PhantomData<F>,
+}
+
+impl<F: PrimeField> ArithmeticChip<F> {
+    // allocate a new unconstrained value
+    fn free(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        value: Value<F>, // this something prover knowns
+    ) -> Result<AssignedCell<F, F>, Error> {
+        // the region is going to have a height of 1
+        // | Advice (advice) | Selector (q_mul) |
+        // |              w0 |                0 |
+        layouter.assign_region(
+            || "free",
+            |mut region| {
+                let w0 = region.assign_advice(|| "w0", self.advice, 0, || value)?;
+                Ok(w0)
+            },
+        )
+    }
+
+    // input = constant
+    fn fixed(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: AssignedCell<F, F>,
+        constant: F, // verifier (fixed in circuit)
+    ) -> Result<(), Error> {
+        // | Advice (advice) | Selector (q_fix) | Fixed (fixed) |
+        // |             w0  |                1 |            c0 |
+        layouter.assign_region(
+            || "fixed",
+            |mut region| {
+                let w0 =
+                    region.assign_advice(|| "w0", self.advice, 0, || input.value().cloned())?;
+                let c0 = region.assign_fixed(|| "c0", self.fixed, 0, || Value::known(constant))?;
+
+                // force input = w0
+                region.constrain_equal(w0.cell(), input.cell())?;
+                self.q_fix.enable(&mut region, 0)?;
+                Ok(())
+            },
+        )
+    }
+
+    // helper function to generate multiplication gates
+    fn mul(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        lhs: AssignedCell<F, F>,
+        rhs: AssignedCell<F, F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        // the region is going to have a height of 3
+        // | Advice (advice) | Selector (q_mul) |
+        // |              w0 |                1 |
+        // |              w1 |                0 |
+        // |              w2 |                0 |
+        layouter.assign_region(
+            || "mul",
+            |mut region| {
+                // turn on the gate
+                self.q_mul.enable(&mut region, 0)?;
+
+                // assign the witness value to the advice column
+                let w0 = region.assign_advice(|| "w0", self.advice, 0, || lhs.value().cloned())?;
+
+                let w1 = region.assign_advice(|| "w1", self.advice, 1, || rhs.value().cloned())?;
+
+                let w2 = region.assign_advice(
+                    || "w2",
+                    self.advice,
+                    2,
+                    || lhs.value().cloned() * rhs.value().cloned(),
+                )?;
+
+                region.constrain_equal(w0.cell(), lhs.cell())?;
+                region.constrain_equal(w1.cell(), rhs.cell())?;
+
+                Ok(w2)
+            },
+        )
+    }
+
+    // helper function to generate multiplication gates
+    fn add(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        lhs: AssignedCell<F, F>,
+        rhs: AssignedCell<F, F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        // the region is going to have a height of 3
+        // | Advice (advice) | Selector (q_mul) |
+        // |              w0 |                1 |
+        // |              w1 |                0 |
+        // |              w2 |                0 |
+        layouter.assign_region(
+            || "add",
+            |mut region| {
+                // turn on the gate
+                self.q_add.enable(&mut region, 0)?;
+
+                // assign the witness value to the advice column
+                let w0 = region.assign_advice(|| "w0", self.advice, 0, || lhs.value().cloned())?;
+
+                let w1 = region.assign_advice(|| "w1", self.advice, 1, || rhs.value().cloned())?;
+
+                let w2 = region.assign_advice(
+                    || "w2",
+                    self.advice,
+                    2,
+                    || lhs.value().cloned() + rhs.value().cloned(),
+                )?;
+
+                region.constrain_equal(w0.cell(), lhs.cell())?;
+                region.constrain_equal(w1.cell(), rhs.cell())?;
+
+                Ok(w2)
+            },
+        )
+    }
+
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        advice: Column<Advice>,
+        fixed: Column<Fixed>,
+    ) -> Self {
+        let q_mul = meta.complex_selector();
+        let q_add = meta.complex_selector();
+        let q_fix = meta.complex_selector();
+
+        // if q_fix = 1: c0 = w0
+        meta.create_gate("fixed", |meta| {
+            let w0 = meta.query_advice(advice, Rotation::cur());
+            let c0 = meta.query_fixed(fixed);
+            let q_fix = meta.query_selector(q_fix);
+            vec![q_fix * (w0 - c0)]
+        });
+
+        // define a new gate:
+        // next = curr + 1 if q_enable is 1
+        meta.create_gate("vertical-mul", |meta| {
+            //            | Advice |
+            // current -> |     w0 |
+            //            |     w1 |
+            //            |     w2 |
+            let w0 = meta.query_advice(advice, Rotation::cur()); // current row
+            let w1 = meta.query_advice(advice, Rotation::next()); // next row
+            let w2 = meta.query_advice(advice, Rotation(2)); // next next row
+
+            let q_mul = meta.query_selector(q_mul);
+
+            // w2 = w1 * w0 <-- sat.
+            vec![q_mul * (w1 * w0 - w2)]
+        });
+
+        // define a new gate:
+        // next = curr + 1 if q_enable is 1
+        meta.create_gate("vertical-add", |meta| {
+            //            | Advice |
+            // current -> |     w0 |
+            //            |     w1 |
+            //            |     w2 |
+            let w0 = meta.query_advice(advice, Rotation::cur()); // current row
+            let w1 = meta.query_advice(advice, Rotation::next()); // next row
+            let w2 = meta.query_advice(advice, Rotation(2)); // next next row
+
+            let q_add = meta.query_selector(q_add);
+
+            // w2 = w1 * w0 <-- sat.
+            vec![q_add * (w1 + w0 - w2)]
+        });
+
+        ArithmeticChip {
+            q_add,
+            q_mul,
+            q_fix,
+            advice,
+            fixed,
+            _ph: PhantomData,
+        }
+    }
+}
+
+impl<F: PrimeField> Circuit<F> for TestCircuit<F> {
+    type Config = TestConfig<F>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        TestCircuit {
+            _ph: PhantomData,
+            a: Value::unknown(),
+            b: Value::unknown(),
+        }
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        let advice = meta.advice_column();
+        let fixed = meta.fixed_column();
+
+        // this will allow us to have equality constraints
+        meta.enable_equality(advice);
+
+        let arith = ArithmeticChip::configure(meta, advice, fixed);
+
+        TestConfig {
+            _ph: PhantomData,
+            fixed,
+            advice,
+            arith,
+        }
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config, //
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let a = config.arith.free(&mut layouter, self.a)?;
+        let b = config.arith.free(&mut layouter, self.b)?;
+        let c = config.arith.mul(&mut layouter, a.clone(), b.clone())?;
+        let d = config.arith.mul(&mut layouter, a.clone(), c.clone())?;
+        config.arith.fixed(&mut layouter, c, F::from_u128(8))?;
+        config.arith.fixed(&mut layouter, d, F::from_u128(16))?;
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/zcash/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/steps_with_fixed.rs
@@ -83,7 +83,6 @@ impl<F: PrimeField> ArithmeticChip<F> {
 
                 // force input = w0
                 region.constrain_equal(w0.cell(), input.cell())?;
-                //println!("input is: {:?}", input);
                 c0.copy_advice(|| "annotation", &mut region, self.advice, 0)?;
                 self.q_fix.enable(&mut region, 0)?;
                 Ok(())

--- a/korrekt/src/sample_circuits/zcash/simple/steps_with_fixed.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/steps_with_fixed.rs
@@ -1,0 +1,275 @@
+// ANCHOR: full
+use std::{marker::PhantomData, net::IpAddr};
+
+use zcash_halo2_proofs::{
+    circuit::{layouter, AssignedCell, Layouter, SimpleFloorPlanner, Value},
+    dev::MockProver,
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
+    poly::Rotation,
+};
+
+use ff::{Field, PrimeField};
+
+// ANCHOR: witness
+pub struct TestCircuit<F: Field> {
+    _ph: PhantomData<F>,
+    a: Value<F>, // secret
+    b: Value<F>, // secret
+}
+
+impl<Fr: PrimeField> Default for TestCircuit<Fr> {
+    fn default() -> Self {
+        TestCircuit {
+            _ph: PhantomData,
+            a: Value::known(Fr::from_u128(2)),
+            b: Value::known(Fr::from_u128(4)),
+        }
+    }
+}
+// ANCHOR_END: witness
+
+#[derive(Clone, Debug)]
+pub struct TestConfig<F: PrimeField> {
+    _ph: PhantomData<F>,
+    advice: Column<Advice>,
+    fixed: Column<Fixed>,
+    arith: ArithmeticChip<F>,
+}
+
+#[derive(Debug, Clone)]
+struct ArithmeticChip<F: PrimeField> {
+    q_add: Selector,
+    q_mul: Selector,
+    q_fix: Selector,
+    advice: Column<Advice>,
+    fixed: Column<Fixed>,
+    _ph: PhantomData<F>,
+}
+
+impl<F: PrimeField> ArithmeticChip<F> {
+    // allocate a new unconstrained value
+    fn free(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        value: Value<F>, // this something prover knowns
+    ) -> Result<AssignedCell<F, F>, Error> {
+        // the region is going to have a height of 1
+        // | Advice (advice) | Selector (q_mul) |
+        // |              w0 |                0 |
+        layouter.assign_region(
+            || "free",
+            |mut region| {
+                let w0 = region.assign_advice(|| "w0", self.advice, 0, || value)?;
+                Ok(w0)
+            },
+        )
+    }
+
+    // input = constant
+    fn fixed(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: AssignedCell<F, F>,
+        constant: F, // verifier (fixed in circuit)
+    ) -> Result<(), Error> {
+        // | Advice (advice) | Selector (q_fix) | Fixed (fixed) |
+        // |             w0  |                1 |            c0 |
+        layouter.assign_region(
+            || "fixed",
+            |mut region| {
+                let w0 =
+                    region.assign_advice(|| "w0", self.advice, 0, || input.value().cloned())?;
+                let c0 = region.assign_fixed(|| "c0", self.fixed, 0, || Value::known(constant))?;
+
+                // force input = w0
+                region.constrain_equal(w0.cell(), input.cell())?;
+                //println!("input is: {:?}", input);
+                c0.copy_advice(||"annotation", &mut region, self.advice, 0)?;
+                self.q_fix.enable(&mut region, 0)?;
+                Ok(())
+            },
+        )
+    }
+
+    // helper function to generate multiplication gates
+    fn mul(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        lhs: AssignedCell<F, F>,
+        rhs: AssignedCell<F, F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        // the region is going to have a height of 3
+        // | Advice (advice) | Selector (q_mul) |
+        // |              w0 |                1 |
+        // |              w1 |                0 |
+        // |              w2 |                0 |
+        layouter.assign_region(
+            || "mul",
+            |mut region| {
+                // turn on the gate
+                self.q_mul.enable(&mut region, 0)?;
+
+                // assign the witness value to the advice column
+                let w0 = region.assign_advice(|| "w0", self.advice, 0, || lhs.value().cloned())?;
+
+                let w1 = region.assign_advice(|| "w1", self.advice, 1, || rhs.value().cloned())?;
+
+                let w2 = region.assign_advice(
+                    || "w2",
+                    self.advice,
+                    2,
+                    || lhs.value().cloned() * rhs.value().cloned(),
+                )?;
+
+                region.constrain_equal(w0.cell(), lhs.cell())?;
+                region.constrain_equal(w1.cell(), rhs.cell())?;
+
+                Ok(w2)
+            },
+        )
+    }
+
+    // helper function to generate multiplication gates
+    fn add(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        lhs: AssignedCell<F, F>,
+        rhs: AssignedCell<F, F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        // the region is going to have a height of 3
+        // | Advice (advice) | Selector (q_mul) |
+        // |              w0 |                1 |
+        // |              w1 |                0 |
+        // |              w2 |                0 |
+        layouter.assign_region(
+            || "add",
+            |mut region| {
+                // turn on the gate
+                self.q_add.enable(&mut region, 0)?;
+
+                // assign the witness value to the advice column
+                let w0 = region.assign_advice(|| "w0", self.advice, 0, || lhs.value().cloned())?;
+
+                let w1 = region.assign_advice(|| "w1", self.advice, 1, || rhs.value().cloned())?;
+
+                let w2 = region.assign_advice(
+                    || "w2",
+                    self.advice,
+                    2,
+                    || lhs.value().cloned() + rhs.value().cloned(),
+                )?;
+
+                region.constrain_equal(w0.cell(), lhs.cell())?;
+                region.constrain_equal(w1.cell(), rhs.cell())?;
+
+                Ok(w2)
+            },
+        )
+    }
+
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        advice: Column<Advice>,
+        fixed: Column<Fixed>,
+    ) -> Self {
+        let q_mul = meta.complex_selector();
+        let q_add = meta.complex_selector();
+        let q_fix = meta.complex_selector();
+
+        // if q_fix = 1: c0 = w0
+        meta.create_gate("fixed", |meta| {
+            let w0 = meta.query_advice(advice, Rotation::cur());
+            let c0 = meta.query_fixed(fixed);
+            let q_fix = meta.query_selector(q_fix);
+            vec![q_fix * (w0 - c0)]
+        });
+
+        // define a new gate:
+        // next = curr + 1 if q_enable is 1
+        meta.create_gate("vertical-mul", |meta| {
+            //            | Advice |
+            // current -> |     w0 |
+            //            |     w1 |
+            //            |     w2 |
+            let w0 = meta.query_advice(advice, Rotation::cur()); // current row
+            let w1 = meta.query_advice(advice, Rotation::next()); // next row
+            let w2 = meta.query_advice(advice, Rotation(2)); // next next row
+
+            let q_mul = meta.query_selector(q_mul);
+
+            // w2 = w1 * w0 <-- sat.
+            vec![q_mul * (w1 * w0 - w2)]
+        });
+
+        // define a new gate:
+        // next = curr + 1 if q_enable is 1
+        meta.create_gate("vertical-add", |meta| {
+            //            | Advice |
+            // current -> |     w0 |
+            //            |     w1 |
+            //            |     w2 |
+            let w0 = meta.query_advice(advice, Rotation::cur()); // current row
+            let w1 = meta.query_advice(advice, Rotation::next()); // next row
+            let w2 = meta.query_advice(advice, Rotation(2)); // next next row
+
+            let q_add = meta.query_selector(q_add);
+
+            // w2 = w1 * w0 <-- sat.
+            vec![q_add * (w1 + w0 - w2)]
+        });
+
+        ArithmeticChip {
+            q_add,
+            q_mul,
+            q_fix,
+            advice,
+            fixed,
+            _ph: PhantomData,
+        }
+    }
+}
+
+impl<F: PrimeField> Circuit<F> for TestCircuit<F> {
+    type Config = TestConfig<F>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        TestCircuit {
+            _ph: PhantomData,
+            a: Value::unknown(),
+            b: Value::unknown(),
+        }
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        let advice = meta.advice_column();
+        let fixed = meta.fixed_column();
+
+        // this will allow us to have equality constraints
+        meta.enable_equality(advice);
+        meta.enable_equality(fixed);
+
+        let arith = ArithmeticChip::configure(meta, advice, fixed);
+
+        TestConfig {
+            _ph: PhantomData,
+            fixed,
+            advice,
+            arith,
+        }
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config, //
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let a = config.arith.free(&mut layouter, self.a)?;
+        let b = config.arith.free(&mut layouter, self.b)?;
+        let c = config.arith.mul(&mut layouter, a.clone(), b.clone())?;
+        let d = config.arith.mul(&mut layouter, a.clone(), c.clone())?;
+        config.arith.fixed(&mut layouter, c, F::from_u128(8))?;
+        config.arith.fixed(&mut layouter, d, F::from_u128(16))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR introduces support for the propagation of fixed cell occurrences within the SMT solver.

Alongside several fixes and improvements:

- Addressed a prior issue where the first `Unassigned` cell in fixed columns was incorrectly assumed to represent the status of the subsequent rows as `Unassigned`. 

- Optimized the process of extracting polynomials to operate only in rows where at least one selector is enabled.
 
- Previously, polynomials that are always zero were not added to the SMT solver, leading to false positive cases tagging fully constrained circuits as underconstrained. The reason was the inclusion of contributing variables without their corresponding polynomial constraints. The fix excludes the variables where the polynomial is excluded.
This fix may introduce a new false negative issue. A TODO has been added to enable the distinction between zero polynomials caused by disabled versus enabled selectors, addressing potential false negatives in under-constrained circuit evaluations.

New circuits featuring fixed cells in permutations have been implemented to test relevant scenarios.