### PR TITLE
ZKR-4661-Distinct-Zero-Polynomials

### DIFF
--- a/korrekt/src/sample_circuits/zcash/simple/mod.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/mod.rs
@@ -2,3 +2,5 @@ pub mod mul;
 pub mod no_selector;
 pub mod steps;
 pub mod steps_with_fixed;
+pub mod zero_with_fixed;
+pub mod zero_with_fixed_in_poly;

--- a/korrekt/src/sample_circuits/zcash/simple/zero_with_fixed.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/zero_with_fixed.rs
@@ -1,0 +1,87 @@
+use group::ff::PrimeField as Field;
+use std::marker::PhantomData;
+use zcash_halo2_proofs::circuit::*;
+use zcash_halo2_proofs::plonk::*;
+use zcash_halo2_proofs::poly::Rotation;
+
+pub struct FixedWithZeroCircuit<F: Field> {
+    _ph: PhantomData<F>,
+}
+
+#[derive(Clone)]
+
+pub struct FixedWithZeroCircuitConfig {
+    a: Column<Advice>,
+    f: Column<Fixed>,
+    s: Selector,
+}
+
+impl<F: Field> Default for FixedWithZeroCircuit<F> {
+    fn default() -> Self {
+        FixedWithZeroCircuit {
+            _ph: PhantomData,
+        }
+    }
+}
+
+impl<F: Field> Circuit<F> for FixedWithZeroCircuit<F> {
+    type Config = FixedWithZeroCircuitConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        let a = meta.advice_column();
+        let f = meta.fixed_column();
+        let s = meta.selector();
+
+        meta.enable_equality(a);
+        meta.enable_equality(f);
+
+        // define gates
+        meta.create_gate("multiplication", |meta| {
+            let b1 = meta.query_advice(a, Rotation::cur());
+            let b2 = meta.query_advice(a, Rotation::next());
+            let b3 = meta.query_advice(a, Rotation(2));
+            let selector = meta.query_selector(s);
+            // b0 * (1-b0)
+            vec![selector * (b1 * b2 - b3)]
+        });
+
+        Self::Config { a, f, s }
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        layouter
+            .assign_region(
+                || "The Region",
+                |mut region| {
+                    config.s.enable(&mut region, 0)?;
+
+                    let b1 = region.assign_advice(|| "b0", config.a, 0, || Value::known(F::ONE))?;
+                    let b2 = region.assign_advice(|| "b0", config.a, 1, || Value::known(F::ONE))?;
+                    let b3 = region.assign_advice(|| "b0", config.a, 2, || Value::known(F::ONE))?;
+
+                    let f1 = region.assign_fixed(|| "c0", config.f, 0, || Value::known(F::ZERO))?;
+
+                    let f2 = region.assign_fixed(|| "c0", config.f, 1, || Value::known(F::ZERO))?;
+
+                    let out = region.constrain_equal(b1.cell(), f1.cell())?;
+
+                    let out = region.constrain_equal(b3.cell(), f2.cell())?;
+
+
+
+                    Ok(out)
+                },
+            )
+            .unwrap();
+        Ok(())
+    }
+}

--- a/korrekt/src/sample_circuits/zcash/simple/zero_with_fixed_in_poly.rs
+++ b/korrekt/src/sample_circuits/zcash/simple/zero_with_fixed_in_poly.rs
@@ -1,0 +1,75 @@
+use group::ff::PrimeField as Field;
+use std::marker::PhantomData;
+use zcash_halo2_proofs::circuit::*;
+use zcash_halo2_proofs::plonk::*;
+use zcash_halo2_proofs::poly::Rotation;
+
+pub struct FixedWithZeroCircuit<F: Field> {
+    _ph: PhantomData<F>,
+}
+
+#[derive(Clone)]
+
+pub struct FixedWithZeroCircuitConfig {
+    a: Column<Advice>,
+    f: Column<Fixed>,
+    s: Selector,
+}
+
+impl<F: Field> Default for FixedWithZeroCircuit<F> {
+    fn default() -> Self {
+        FixedWithZeroCircuit {
+            _ph: PhantomData,
+        }
+    }
+}
+
+impl<F: Field> Circuit<F> for FixedWithZeroCircuit<F> {
+    type Config = FixedWithZeroCircuitConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        let a = meta.advice_column();
+        let f = meta.fixed_column();
+        let s = meta.selector();
+
+        meta.enable_equality(a);
+        meta.enable_equality(f);
+
+        // define gates
+        meta.create_gate("multiplication", |meta| {
+            let b1 = meta.query_advice(a, Rotation::cur());
+            let f = meta.query_fixed(f);
+            let b3 = meta.query_advice(a, Rotation::next());
+            let selector = meta.query_selector(s);
+            // b0 * (1-b0)
+            vec![selector * (b1 * f - b3)]
+        });
+
+        Self::Config { a, f, s }
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        layouter
+            .assign_region(
+                || "The Region",
+                |mut region| {
+                    config.s.enable(&mut region, 0)?;
+
+                    let out = region.assign_fixed(|| "f1", config.f, 0, || Value::known(F::from_u128(2)))?;//Value::known(F::ZERO))?;
+
+                    Ok(out)
+                },
+            )
+            .unwrap();
+        Ok(())
+    }
+}

--- a/korrekt/src/test/integration_tests_zcash.rs
+++ b/korrekt/src/test/integration_tests_zcash.rs
@@ -911,4 +911,63 @@ mod tests {
         println!("output_status: {:?}", output_status);
         assert!(output_status.eq(&AnalyzerOutputStatus::NotUnderconstrainedLocal));
     }
+    #[test]
+    fn analyze_underconstrained_zero_fixed() {
+        let circuit = sample_circuits::simple::zero_with_fixed::FixedWithZeroCircuit::<Fr>::default();
+        let k = 11;
+       
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instance_cells: HashMap::new(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let mut analyzer = Analyzer::new(
+            &circuit,
+            k,
+            AnalyzerType::UnderconstrainedCircuit,
+            Some(&analyzer_input),
+        )
+        .unwrap();
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input)
+            .unwrap()
+            .output_status;
+        println!("output_status: {:?}", output_status);
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
+
+    #[test]
+    fn analyze_underconstrained_zero_with_fixed_in_poly() {
+        let circuit = sample_circuits::simple::zero_with_fixed_in_poly::FixedWithZeroCircuit::<Fr>::default();
+        let k = 11;
+       
+        let analyzer_input: analyzer_io_type::AnalyzerInput = analyzer_io_type::AnalyzerInput {
+            verification_method: VerificationMethod::Random,
+            verification_input: VerificationInput {
+                instance_cells: HashMap::new(),
+                iterations: 5,
+            },
+            lookup_method: LookupMethod::InlineConstraints,
+        };
+
+        let mut analyzer = Analyzer::new(
+            &circuit,
+            k,
+            AnalyzerType::UnderconstrainedCircuit,
+            Some(&analyzer_input),
+        )
+        .unwrap();
+
+        let output_status = analyzer
+            .analyze_underconstrained(&analyzer_input)
+            .unwrap()
+            .output_status;
+        println!("output_status: {:?}", output_status);
+        assert!(output_status.eq(&AnalyzerOutputStatus::Underconstrained));
+    }
 }


### PR DESCRIPTION
This PR introduces a new classification for ZERO polynomials within our SMT solver, aiming to differentiate between two scenarios:

Selector Disabled: The polynomial is zero because the selector is disabled.
Selector Enabled: The polynomial remains zero even when the selector is enabled.

Previously, our analyzer could experience false negatives in situations where selectors were active but polynomials still evaluated to zero, potentially pointing to underconstrained circuits. This update resolves these inaccuracies by providing clearer distinctions.