### PR TITLE
ZKR-5610-Remove-Test-Thread-Limit

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[env]
-RUST_TEST_THREADS = "1"

--- a/README.md
+++ b/README.md
@@ -158,16 +158,16 @@ Replace `[OPTIONS]` with the desired options as described below.
 2. Run `cargo test` for the default feature flag (`use_zcash_halo2_proofs`).
 
     ```bash
-    cargo test
+    cargo test -- --test-threads=1
     ```
 
    For other versions of halo2 run `cargo test` with relevant halo2 version feature flag:
 
     ```bash
-    cargo test --no-default-features --features use_pse_halo2_proofs
-    cargo test --no-default-features --features use_axiom_halo2_proofs
-    cargo test --no-default-features --features use_scroll_halo2_proofs
-    cargo test --no-default-features --features use_pse_v1_halo2_proofs
+    cargo test --no-default-features --features use_pse_halo2_proofs -- --test-threads=1
+    cargo test --no-default-features --features use_axiom_halo2_proofs -- --test-threads=1
+    cargo test --no-default-features --features use_scroll_halo2_proofs -- --test-threads=1
+    cargo test --no-default-features --features use_pse_v1_halo2_proofs -- --test-threads=1
     ```
 
 ## For linting


### PR DESCRIPTION
This PR removes the `[env] RUST_TEST_THREADS = "1"` setting from the `config.toml` file, which was previously limiting the tests to a single thread. By removing this setting, we allow the system to utilize multiple CPU core.

Additionally, the README has been updated to reflect that test commands should now explicitly limit thread usage where necessary. This is especially important when multiple tests are running concurrently to prevent conflicts when reading from or writing to the same file.